### PR TITLE
declare SystemRequirements in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ Suggests:
     streamR,
     XML,
     testthat
+SystemRequirements: pdftotext, antiword
 URL: http://github.com/kbenoit/readtext
 Encoding: UTF-8
 BugReports: https://github.com/kbenoit/readtext/issues


### PR DESCRIPTION
This will help you avoid a potential CRAN submission issue given the system calls. See, for example, https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#The-DESCRIPTION-file