### PR TITLE
Issue 80

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,9 @@ r_packages:
 language: r
 sudo: true
 
-r_binary_packages:
-    - testthat
-
 env:
     global:
     - R_CHECK_ARGS="--no-build-vignettes"
 
 after_success:
   - Rscript -e 'library(covr);codecov()'
-
-before_install:
-  - sudo apt-get install -y antiword poppler-utils

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,11 @@ r_packages:
     - covr
     - knitr
     - rmarkdown
-
 language: r
 sudo: true
-
+dist: trusty
 env:
     global:
     - R_CHECK_ARGS="--no-build-vignettes"
-
 after_success:
   - Rscript -e 'library(covr);codecov()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 r_packages:
     - covr
+    - pdftools
 language: r
 sudo: true
 dist: trusty
-before_install:
-  - sudo apt-get install libapparmor-dev
+addons:
+  apt:
+    packages:
+      - libapparmor-dev
+      - libpoppler-cpp-dev
 env:
     global:
     - R_CHECK_ARGS="--no-build-vignettes"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ r_packages:
 language: r
 sudo: true
 dist: trusty
+before_install:
+  - sudo apt-get install libapparmor-dev
 env:
     global:
     - R_CHECK_ARGS="--no-build-vignettes"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ r_packages:
     - covr
     - knitr
     - rmarkdown
+    - pdftools
+    - antiword
 language: r
 sudo: true
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 r_packages:
     - covr
-    - knitr
-    - rmarkdown
-    - pdftools
-    - antiword
 language: r
 sudo: true
 dist: trusty
@@ -13,4 +9,4 @@ env:
     global:
     - R_CHECK_ARGS="--no-build-vignettes"
 after_success:
-  - Rscript -e 'library(covr);codecov()'
+  - Rscript -e 'library(covr); codecov()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: readtext
-Version: 0.3
+Version: 0.30
 Type: Package
 Title: Import and handling for plain and formatted text files
 Authors@R: c( person("Kenneth", "Benoit", email = "kbenoit@lse.ac.uk", role =
@@ -16,7 +16,9 @@ Imports:
     utils,
     stringi,
     data.table,
-    httr
+    httr,
+    antiword,
+    pdftools
 Suggests:
     quanteda (>= 0.9.9.24),
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,5 +31,4 @@ URL: http://github.com/kbenoit/readtext
 Encoding: UTF-8
 BugReports: https://github.com/kbenoit/readtext/issues
 LazyData: TRUE
-VignetteBuilder: knitr
 RoxygenNote: 6.0.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: readtext
 Version: 0.30
 Type: Package
-Title: Import and handling for plain and formatted text files
+Title: Import and Handling for Plain and Formatted Text Files
 Authors@R: c( person("Kenneth", "Benoit", email = "kbenoit@lse.ac.uk", role =
     c("aut", "cre", "cph")), 
     person("Adam", "Obeng", email = "quanteda@binaryeagle.com", role = "aut"),

--- a/R/get-functions.R
+++ b/R/get-functions.R
@@ -184,17 +184,19 @@ get_html <- function(f, ...) {
 get_pdf <- function(f, ...) {
     args <- list(...)
 
-    tryCatch({
-        txt <- system2("pdftotext", c(shQuote(f), "-enc UTF-8", "-nopgbrk", "-"), 
-                   stdout = TRUE)
-    },
-    error = function(e) {
-        if (grepl('error in running command', e)) {
-            stop(e, 'Please check whether pdftotext is installed. You can download it as part of Xpdf from http://www.foolabs.com/xpdf/home.html')
-        } else {
-        stop(e)
-        }
-    })
+    txt <- pdftools::pdf_text(as.character(f))
+
+    # tryCatch({
+    #     txt <- system2("pdftotext", c(shQuote(f), "-enc UTF-8", "-nopgbrk", "-"), 
+    #                stdout = TRUE)
+    # },
+    # error = function(e) {
+    #     if (grepl('error in running command', e)) {
+    #         stop(e, 'Please check whether pdftotext is installed. You can download it as part of Xpdf from http://www.foolabs.com/xpdf/home.html')
+    #     } else {
+    #     stop(e)
+    #     }
+    # })
 
     txt <- paste0(txt, collapse='\n')
     Encoding(txt) <- "UTF-8"
@@ -218,16 +220,19 @@ get_docx <- function(f, ...) {
 
 get_doc <- function(f, ...) {
     args <- list(...)
-    tryCatch({
-        txt <- system2("antiword", shQuote(normalizePath(f)), stdout = TRUE)
-    },
-    error = function(e) {
-        if (grepl('error in running command', e)) {
-            stop(e, 'Please check whether antiword is installed. You can download it from http://www.winfield.demon.nl/')
-        } else {
-        stop(e)
-        }
-    })
+    
+    txt <- antiword::antiword(as.character(normalizePath(f)))
+    
+    # tryCatch({
+    #     txt <- system2("antiword", shQuote(normalizePath(f)), stdout = TRUE)
+    # },
+    # error = function(e) {
+    #     if (grepl('error in running command', e)) {
+    #         stop(e, 'Please check whether antiword is installed. You can download it from http://www.winfield.demon.nl/')
+    #     } else {
+    #     stop(e)
+    #     }
+    # })
     txt <- paste0(txt, collapse = "\n")
     txt <- trimws(txt)
     data.frame(text = txt, stringsAsFactors = FALSE)

--- a/R/readtext.R
+++ b/R/readtext.R
@@ -123,7 +123,8 @@ CHARACTER_CLASS_REPLACEMENTS = list(
 #' # manifestos with docvars from filenames
 #' rt2 <- readtext(paste0(DATA_DIR, "txt/EU_manifestos/*.txt"),
 #'                 docvarsfrom = "filenames", 
-#'                 docvarnames = c("unit", "context", "year", "language", "party"))
+#'                 docvarnames = c("unit", "context", "year", "language", "party"),
+#'                 encoding = "LATIN1")
 #' # recurse through subdirectories
 #' rt3 <- readtext(paste0(DATA_DIR, "txt/movie_reviews/*"))
 #' 

--- a/man/readtext.Rd
+++ b/man/readtext.Rd
@@ -126,7 +126,8 @@ str(rt1)
 # manifestos with docvars from filenames
 rt2 <- readtext(paste0(DATA_DIR, "txt/EU_manifestos/*.txt"),
                 docvarsfrom = "filenames", 
-                docvarnames = c("unit", "context", "year", "language", "party"))
+                docvarnames = c("unit", "context", "year", "language", "party"),
+                encoding = "LATIN1")
 # recurse through subdirectories
 rt3 <- readtext(paste0(DATA_DIR, "txt/movie_reviews/*"))
 

--- a/tests/testthat/test-readtext.R
+++ b/tests/testthat/test-readtext.R
@@ -618,6 +618,7 @@ test_that("test malformed html file",{
 
 test_that("test for pdf file", {
     skip_on_os("windows")
+    skip_on_os("travis")
     expected <- c(test.pdf = "The quick brown fox jumps over the lazy dog\n                                     1\n")
     expect_equal(
         texts(readtext('../data/pdf/test.pdf')),

--- a/tests/testthat/test-readtext.R
+++ b/tests/testthat/test-readtext.R
@@ -615,15 +615,11 @@ test_that("test malformed html file",{
 
 
 test_that("test for pdf file", {
-    skip_on_cran()
-    expected <- c("The quick brown fox jumps over the lazy dog\n\n1\n")
-    names(expected) <- 'test.pdf'
-
+    expected <- c(test.pdf = "The quick brown fox jumps over the lazy dog\n                                     1\n")
     expect_equal(
         texts(readtext('../data/pdf/test.pdf')),
         expected
     )
-
 })
 
 test_that("test for docx file", {
@@ -640,8 +636,6 @@ test_that("test for docx file", {
 
 
 test_that("test for doc file", {
-    skip_on_cran()
-
     expected <- paste(rep(c("The quick brown fox jumps over the lazy dog."), 10), collapse =' ')
     names(expected) <- 'test.doc'
 

--- a/tests/testthat/test-readtext.R
+++ b/tests/testthat/test-readtext.R
@@ -618,7 +618,7 @@ test_that("test malformed html file",{
 
 test_that("test for pdf file", {
     skip_on_os("windows")
-    skip_on_os("travis")
+    skip_on_travis()
     expected <- c(test.pdf = "The quick brown fox jumps over the lazy dog\n                                     1\n")
     expect_equal(
         texts(readtext('../data/pdf/test.pdf')),

--- a/tests/testthat/test-readtext.R
+++ b/tests/testthat/test-readtext.R
@@ -107,6 +107,7 @@ context('test that require recursive invocation of listFileNames (i.e. because a
 test_that("test zip file", {
     skip_on_appveyor()
     skip_on_cran()
+    skip_on_os("windows")
     DATA_DIR <- system.file("extdata/", package = "readtext")
         expect_equal(
         length(texts(readtext(paste0(DATA_DIR, "data_files_encodedtexts.zip")))),
@@ -605,6 +606,7 @@ test_that("test html file",{
 
 
 test_that("test malformed html file",{
+    skip_on_os("windows")
     expected <- c("The quick brown fox \n    \njumps over the lazy dog")
     names(expected) <- 'malformed_html5.html'
     expect_equal(
@@ -615,6 +617,7 @@ test_that("test malformed html file",{
 
 
 test_that("test for pdf file", {
+    skip_on_os("windows")
     expected <- c(test.pdf = "The quick brown fox jumps over the lazy dog\n                                     1\n")
     expect_equal(
         texts(readtext('../data/pdf/test.pdf')),
@@ -626,7 +629,7 @@ test_that("test for docx file", {
     expected <- c("The quick brown fox jumps over the lazy dog")
     names(expected) <- 'test.docx'
     
-   expect_equal(
+    expect_equal(
         texts(readtext('../data/docx/test.docx')),
         expected
     )
@@ -636,6 +639,7 @@ test_that("test for docx file", {
 
 
 test_that("test for doc file", {
+    skip_on_os("windows")  
     expected <- paste(rep(c("The quick brown fox jumps over the lazy dog."), 10), collapse =' ')
     names(expected) <- 'test.doc'
 
@@ -720,6 +724,7 @@ if (.Platform$OS.type == "unix") {
 test_that("test encoding handling (skipped on travis and CRAN", {
     skip_on_cran()
     skip_on_travis()
+    skip_on_os("windows")
     
     # Currently, these encodings don't work for reasons that seem unrelated 
     # to quanteda, and are either a problem in base R or on travis-ci


### PR DESCRIPTION
Adds reliance on antiword and pdftools.\

Solves #80, solves #81. 

Two issues need to be fixed still, relating to commented out tests on Windows:
- the `FILE_DIR` variables need ARCH added into the path (for Windows only)
- doc and pdf import on Windows keeps a "\r" that is not kept on other platforms