### PR TITLE
Add initial version of readtext vignette

### DIFF
--- a/vignettes/mystyle.css
+++ b/vignettes/mystyle.css
@@ -1,0 +1,278 @@
+/* This css file taken from Winston Chang at https://github.com/wch/R6/tree/master/vignettes */
+
+
+body {
+  background-color: #fff;
+  margin: 0 auto;
+  max-width: 800px;
+  float: center;
+  margin-left: auto;
+  margin-right: auto;
+  overflow: visible;
+}
+  body #header {
+    clear: both;
+    margin-bottom: 8px;
+    border-bottom: 2px solid #999;
+    font-size: 20px;
+    padding: 2px 10px 2px 25px;
+  }
+  body #content {
+    background-color: white;
+    clear: both;
+    float: left;
+    overflow: visible;
+    padding: 10px;
+    border: 1px solid #BBBBBB;
+    border-radius: 5px;
+    width: 780px;
+  }
+  body #footer {
+    background-color: #99BBDD;
+    clear: both;
+    float: left;
+    margin: 8px 0;
+    border: 1px solid #6688AA;
+    border-radius: 5px;
+    padding: 0 10px;
+    width: 780px;
+  }
+body .clear {
+  clear: both;
+  border-width: 0;
+  margin: 0;
+  visibility: hidden;
+}
+
+#TOC {
+  clear: both;
+  margin: 0 0 10px 10px;
+  padding: 4px;
+  width: 400px;
+  border: 1px solid #CCCCCC;
+  border-radius: 5px;
+
+  background-color: #f6f6f6;
+  font-size: 13px;
+  line-height: 16px;
+}
+  #TOC .toctitle {
+    font-weight: bold;
+    font-size: 15px;
+    margin-left: 5px;
+  }
+
+  #TOC ul {
+    padding-left: 40px;
+    margin-left: -1.5em;
+    margin-top: 5px;
+    margin-bottom: 5px;
+  }
+  #TOC ul ul {
+    margin-left: -2em;
+  }
+  #TOC li {
+    line-height: 16px;
+  }
+
+table {
+  margin-left: 25px;
+  border-width: 1px;
+  border-spacing: 0px;
+  border-style: outset;
+  border-color: gray;
+  border-collapse: collapse;
+}
+table th {
+  border-width: 1px;
+  padding: 5px;
+  border-style: inset;
+  border-color: #DDDDDD;
+  background-color: white;
+}
+table td {
+  border-width: 1px;
+  border-style: inset;
+  border-color: #DDDDDD;
+  background-color: white;
+  line-height: 18px;
+  padding: 2px 5px;
+}
+
+p {
+  margin-left: 15px;
+  margin-bottom: 5px;
+}
+
+blockquote {
+  background-color: #f6f6f6;
+  padding: 13px;
+  padding-bottom: 1px;
+}
+
+hr {
+  border-style: solid;
+  border: none;
+  border-top: 1px solid #777;
+  margin: 28px 0;
+}
+
+dl {
+  margin-left: 0;
+}
+  dl dd {
+    margin-bottom: 13px;
+    margin-left: 13px;
+  }
+
+ul {
+  margin-top: 0;
+}
+  ul li {
+    list-style: circle outside;
+  }
+  ul ul {
+    margin-bottom: 0;
+  }
+
+code {
+  font-family: Consolas, Monaco, 'Courier New', monospace;
+  color: #000;
+  padding: 0px;
+}
+
+p > code, li > code {
+  color: #333;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  background-color: #f8f8f8;
+  font-size: 80%;
+  padding: 0px 2px;
+}
+
+/*pre > code {
+  font-size: 12px;
+  line-height: 16px;
+}*/
+
+pre {
+  font-size: 12px;
+  line-height: 16px;
+  white-space: pre-wrap;    /* Wrap long lines */
+}
+
+pre.r {
+  background-color: #F3F5F7;
+  padding: 4px 10px;
+  border: 1px solid #AEBDCC;
+  border-radius: 5px;
+  margin: 5px 5px 10px 20px;
+}
+
+img {
+  background-color: #FFFFFF;
+  padding: 2px;
+  border: 1px solid #DDDDDD;
+  border-radius: 3px;
+  border: 1px solid #CCCCCC;
+  box-shadow: 2px 2px 12px -5px #999999;
+  margin: 0 5px;
+}
+
+body {
+  font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 15px;
+  line-height: 22px;
+}
+  body #header {
+  }
+
+
+h1 {
+  margin-top: 0;
+  font-size: 35px;
+  line-height: 40px;
+}
+
+h2 {
+  border-bottom: 2px solid #ccc;
+  width: 85%;
+  padding-top: 10px;
+  font-size: 22px;
+}
+
+h3 {
+  border-bottom: 2px solid #ccc;
+  width: 75%;
+  padding-top: 10px;
+  font-size: 18px;
+}
+
+h4 {
+  border-bottom: 1px solid #ccc;
+  width: 60%;
+  margin-left: 8px;
+  font-size: 16px;
+}
+
+h5, h6 {
+  border-bottom: 1px solid #ccc;
+  width: 60%;
+  margin-left: 15px;
+  font-size: 16px;
+}
+
+h4.author {
+  border-bottom: none;
+}
+
+a {
+  color: #0033dd;
+  text-decoration: none;
+}
+  a:hover {
+    color: #6666ff; }
+  a:visited {
+    color: #800080; }
+  a:visited:hover {
+    color: #BB00BB; }
+  a[href^="http:"] {
+    text-decoration: underline; }
+  a[href^="https:"] {
+    text-decoration: underline; }
+
+dl dt {
+  font-weight: bold;
+}
+
+
+pre .operator,
+pre .paren {
+  color: #888;
+}
+
+pre .literal {
+ color: #990073;
+}
+
+pre .number {
+ color: #0080C0;
+}
+
+pre .comment {
+ color: #008000;
+ font-style: italic
+}
+
+pre .keyword {
+ color: #900;
+ font-weight: bold
+}
+
+pre .identifier {
+ color: #000;
+}
+
+pre .string {
+ color: #b44;
+}

--- a/vignettes/readtext_vignette.Rmd
+++ b/vignettes/readtext_vignette.Rmd
@@ -19,7 +19,7 @@ library(readtext)
 
 The vignette walks you through importing a variety of different text files into R using the **readtext** package. Currently, **readtext** supports plain text files (.txt), data in some form of JavaScript Object Notation (.json), comma-or tab-separated values (.csv, .tab, .tsv), XML documents (.xml), as well as PDF and Microsoft Word formatted files (.pdf, .doc, .docx).
 
-**readtext** also handles multiple files and file types using for instance a "glob" expression, files from a URL or an archive file (.zip, .tar, .tar.gz, .tar.bz). Usually, you do not have to determine the format of the files explicitly -- **readtext** takes this information from the file ending.
+**readtext** also handles multiple files and file types using for instance a "glob" expression, files from a URL or an archive file (.zip, .tar, .tar.gz, .tar.bz). Usually, you do not have to determine the format of the files explicitly - **readtext** takes this information from the file ending.
 
 The **readtext** package comes with a data directory called `extdata` that contains examples of all files listed above. In the vignette, we use this data directory.
 
@@ -136,7 +136,7 @@ Encoding(rt_docx$text)
 You can also read in text directly from a URL.
 
 ```{r}
-# Note: Example required -- which URL should we use?
+# Note: Example required: which URL should we use?
 ```
 
 ## 2.7 Text from archive files (.zip, .tar, .tar.gz, .tar.bz)

--- a/vignettes/readtext_vignette.Rmd
+++ b/vignettes/readtext_vignette.Rmd
@@ -1,0 +1,287 @@
+---
+title: "Read text files with readtext()"
+output: 
+  rmarkdown::html_vignette:
+    css: mystyle.css
+    toc: yes
+vignette: >
+  %\VignetteIndexEntry{Readtextfiles}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r eval=TRUE, message = FALSE}
+# Load readtext package
+library(readtext)
+```
+
+# 1. Introduction
+
+The vignette walks you through importing a variety of different text files into R using the **readtext** package. Currently, **readtext** supports plain text files (.txt), data in some form of JavaScript Object Notation (.json), comma-or tab-separated values (.csv, .tab, .tsv), XML documents (.xml), as well as PDF and Microsoft Word formatted files (.pdf, .doc, .docx).
+
+**readtext** also handles multiple files and file types using for instance a "glob" expression, files from a URL or an archive file (.zip, .tar, .tar.gz, .tar.bz). Usually, you do not have to determine the format of the files explicitly -- **readtext** takes this information from the file ending.
+
+The **readtext** package comes with a data directory called `extdata` that contains examples of all files listed above. In the vignette, we use this data directory.
+
+```{r}
+# Get the data directory from readtext
+DATA_DIR <- system.file("extdata/", package = "readtext")
+```
+
+The `extdata` directory contains several subfolders that include different text files. In the following examples, we load one or more files stored in each of these folders. The `paste0` command is used to concatenate the `extdata` folder from the 
+**readtext** package with the subfolders. When reading in custom text files, you will need to determine your own data directory (see `?setwd()`). 
+
+
+# 2. Reading one or more text files
+
+## 2.1 Plain text files (.txt)
+
+The folder "txt" contains a subfolder named UDHR with .txt files of the Universal Declaration of Human Rights in 13 languages. 
+
+```{r}
+# Read in all files from a folder
+rt_txt_1 <- readtext(paste0(DATA_DIR, "txt/UDHR/*"))
+str(rt_txt_1)
+```
+
+We can specify document-level metadata (`docvars`) based on the file names or on a separate data.frame. Below we take the docvars from the filenames (`docvarsfrom = "filenames"`) and set the names for each variable (`docvarnames = c("unit", "context", "year", "language", "party")`). The command `dvsep = "_"` determines the separator (a regular expression character string) included in the filenames to delimit the `docvar` elements. 
+
+```{r}
+# Manifestos with docvars from filenames
+rt_txt_2 <- readtext(paste0(DATA_DIR, "txt/EU_manifestos/*.txt"),
+                docvarsfrom = "filenames", 
+                docvarnames = c("unit", "context", "year", "language", "party"),
+                dvsep = "_")
+
+str(rt_txt_2)
+```
+
+**readtext** can also curse through subdirectories. In our example, the folder `txt/movie_reviews` contains two subfolders (called `neg` and `pos`). We can load all texts included in both folders. 
+
+```{r}
+# Recurse through subdirectories
+rt_txt_3 <- readtext(paste0(DATA_DIR, "txt/movie_reviews/*"))
+str(rt_txt_3)
+```
+
+## 2.2 Comma- or tab-separated values (.csv, .tab, .tsv)
+
+Read in comma separted values (.csv files) that contain textual data. We determine the `texts` variable in our .csv file as the `textfield`. This is the column that contains the actual text. The other columns of the original csv file (`Year`, `President`, `FirstName`) are by default treated as document-level variables. 
+
+```{r}
+# Read in comma-separated values
+rt_csv <- readtext(paste0(DATA_DIR, "csv/inaugCorpus.csv"), textfield = "texts")
+str(rt_csv)
+```
+
+The same procedure applies to tab-separated values.
+
+```{r}
+# Read in tab-separated values
+rt_tsv <- readtext(paste0(DATA_DIR, "tsv/dailsample.tsv"), textfield = "speech")
+str(rt_tsv)
+```
+
+## 2.3 JSON data (.json)
+
+You can also read .json data. Again you need to specify the `textfield`. 
+
+```{r}
+## Read in JSON data
+rt_json <- readtext(paste0(DATA_DIR, "json/inaugural_sample.json"), textfield = "texts")
+str(rt_json)
+```
+
+## 2.4 PDF files
+
+**readtext** can also read in .pdf files after converting them through `pdftotext`. In older versions this required `xpdf` to be installed, either through `brew install xpdf` (macOS; see extensively <https://brew.sh>) or from <http://www.winfield.demon.nl> (Windows). Note that the most recent version of **readtext** should install this software automatically.
+
+In the example below we load all .pdf files stored in the `UDHR` folder, and determine that the `docvars` shall be taken from the filenames. We call the document-level variables `document` and `language`, and specify the delimiter (`dvsep`).
+
+```{r}
+## Read in Universal Declaration of Human Rights pdf files
+rt_pdf <- readtext(paste0(DATA_DIR, "pdf/UDHR/*.pdf"), 
+                docvarsfrom = "filenames", 
+                docvarnames = c("document", "language"),
+                sep = "_")
+str(rt_pdf)
+```
+
+We can always check the encoding of each file. 
+
+```{r}
+Encoding(rt_pdf$text)
+```
+
+## 2.5 Microsoft Word files (.doc, .docx)
+
+Microsoft Word formatted files are converted through `antiword`. In older versions you might need to install `antiword` either through `brew install antiword` (macOS; see extensively <https://brew.sh>) or from <http://www.winfield.demon.nl> (Windows). Again, the most recent version of **readtext** should install `antiword` by default. If it is not working try:
+
+```{r, message = FALSE, eval = FALSE}
+install.packages("antiword")
+require(antiword)
+```
+
+
+```{r}
+## Read in Word data (.docx)
+rt_docx <- readtext(paste0(DATA_DIR, "word/*.docx"))
+
+str(rt_docx)
+Encoding(rt_docx$text)
+```
+
+## 2.6 Text from URLs
+
+You can also read in text directly from a URL.
+
+```{r}
+# Note: Example required -- which URL should we use?
+```
+
+## 2.7 Text from archive files (.zip, .tar, .tar.gz, .tar.bz)
+
+Finally, it is possible to inclue text from archives.
+
+```{r}
+# Note: Archive file required. The only zip archive included in readtext has 
+# different encodings and is difficult to import (see section 4.2).
+```
+
+# 3. Inter-operability with quanteda
+
+**readtext** was originally developed in early versions of the [**quanteda**](https://github.com/kbenoit/quanteda) package for the quantitative analysis of textual data. It was spawned from the `textfile()` function from that package, and now lives exclusively in **readtext**. Because **quanteda**'s corpus constructor recognizes the data.frame format returned by `readtext()`, it can construct a corpus directly from a `readtext` object, preserving all docvars and other meta-data.
+
+```{r, message = FALSE}
+require(quanteda)
+```
+
+You can easily contruct a corpus from a **readtext** object.
+
+```{r}
+# Read in comma-separated values with readtext
+rt_csv <- readtext(paste0(DATA_DIR, "csv/inaugCorpus.csv"), textfield = "texts")
+
+# Create quanteda corpus
+corpus_csv <- quanteda::corpus(rt_csv)
+
+summary(corpus_csv, 5)
+```
+
+# 4. Solving common problems 
+
+## 4.1 Remove page numbers using regular expressions
+
+When a document contains page numbers, they are imported as well. If you want to remove them, you can use a regular expression. We strongly recommend using the [**stringi**](https://github.com/gagolews/stringi) package. For the most common regular expressions you can look at this [cheatsheet](http://web.mit.edu/hackl/www/lab/turkshop/slides/regex-cheatsheet.pdf).
+
+You first need to check in the original file in which format the page numbers occur (e.g., "1", "-1-", "page 1" etc.). We can make use of the fact that page numbers are almost always preceded and followed by a linebreak (`\n`). After loading the text with **readtext**, you can replace the page numbers. 
+
+```{r, message = FALSE}
+# Load stringi package
+require(stringi)
+```
+
+In the first example, the page numbers have the format "page X".
+
+```{r}
+# Make some text with page numbers
+sample_text_a <- "The quick brown fox named Seamus jumps over the lazy dog also named Seamus, 
+page 1 
+with the newspaper from a boy named quick Seamus, in his mouth.
+page 2
+The quicker brown fox jumped over 2 lazy dogs."
+
+sample_text_a
+
+# Remove "page" and respective digit
+sample_text_a2 <- unlist(stri_split_fixed(sample_text_a, '\n'), use.names = FALSE)
+sample_text_a2 <- stri_replace_all_regex(sample_text_a2, "page \\d*", "")
+sample_text_a2 <- stri_trim_both(sample_text_a2)
+sample_text_a2 <- sample_text_a2[sample_text_a2 != '']
+stri_paste(sample_text_a2, collapse = '\n')
+```
+In the second example we remove page numbers which have the format "- X -".
+
+```{r}
+sample_text_b <- "The quick brown fox named Seamus 
+- 1 - 
+jumps over the lazy dog also named Seamus, with 
+- 2 - 
+the newspaper from a boy named quick Seamus, in his mouth. 
+- 33 - 
+The quicker brown fox jumped over 2 lazy dogs."
+
+sample_text_b
+
+sample_text_b2 <- unlist(stri_split_fixed(sample_text_b, '\n'), use.names = FALSE)
+sample_text_b2 <- stri_replace_all_regex(sample_text_b2, "[-] \\d* [-]", "")
+sample_text_b2 <- stri_trim_both(sample_text_b2)
+sample_text_b2 <- sample_text_b2[sample_text_b2 != '']
+stri_paste(sample_text_b2, collapse = '\n')
+```
+
+Such **stringi** functions can also be applied to **readtext** objects. 
+
+## 4.2 Read files with different encodings
+
+Sometimes files of the same type have different encodings. If the encoding of a file is included in the file name, we can extract this information and import the texts correctly. 
+
+```{r}
+# Create a temporary directory to extract the .zip file
+FILEDIR <- tempdir()
+
+# Unzip file
+unzip(system.file("extdata", "data_files_encodedtexts.zip", package = "readtext"), exdir = FILEDIR)
+```
+
+```{r}
+# Get encoding from filename
+filenames <- list.files(FILEDIR, "\\.txt$")
+
+head(filenames)
+
+# Strip the extension
+filenames <- gsub(".txt$", "", filenames)
+parts <- strsplit(filenames, "_")
+fileencodings <- sapply(parts, "[", 3)
+
+head(fileencodings)
+
+# Check whether certain file encodings are not supported
+notAvailableIndex <- which(!(fileencodings %in% iconvlist()))
+fileencodings[notAvailableIndex]
+```
+
+If we read the text files without specifying the encoding, we get errendously formatted text. To avoid this, we determine the `encoding` using the character object `fileencoding` created above. 
+
+```{r}
+# Read txt files
+txts <- readtext(paste0(FILEDIR,  "/", "*.txt"), encoding = fileencodings)
+
+substring(texts(txts)[1], 1, 40)  # English, looking good
+
+substring(texts(txts)[4], 1, 40)  # Arabic, looking good 
+
+substring(texts(txts)[40], 1, 40) # Cyrillic, looking good
+
+substring(texts(txts)[7], 1, 40)  # Chinese, looking good
+
+substring(texts(txts)[26], 1, 40) # Hindi, looking good
+```
+
+Again, we can add `docvars` based on the filenames.
+
+```{r}
+txts <- readtext(paste0(FILEDIR, "/", "*.txt"), 
+                 encoding = fileencodings,
+                 docvarsfrom = "filenames", 
+                 docvarnames = c("document", "language", "input_encoding"))
+```
+
+From this file we can easily create a **quanteda** `corpus` object.
+
+```{r}
+corpus_txts <- corpus(txts)
+
+summary(corpus_txts, 5)
+```

--- a/vignettes/vignette_readtext.html
+++ b/vignettes/vignette_readtext.html
@@ -1,0 +1,382 @@
+<!DOCTYPE html>
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+
+<meta charset="utf-8">
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="generator" content="pandoc" />
+
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+
+
+<title>Read text files with readtext()</title>
+
+
+
+<style type="text/css">code{white-space: pre;}</style>
+<style type="text/css">
+div.sourceCode { overflow-x: auto; }
+table.sourceCode, tr.sourceCode, td.lineNumbers, td.sourceCode {
+  margin: 0; padding: 0; vertical-align: baseline; border: none; }
+table.sourceCode { width: 100%; line-height: 100%; }
+td.lineNumbers { text-align: right; padding-right: 4px; padding-left: 4px; color: #aaaaaa; border-right: 1px solid #aaaaaa; }
+td.sourceCode { padding-left: 5px; }
+code > span.kw { color: #007020; font-weight: bold; } /* Keyword */
+code > span.dt { color: #902000; } /* DataType */
+code > span.dv { color: #40a070; } /* DecVal */
+code > span.bn { color: #40a070; } /* BaseN */
+code > span.fl { color: #40a070; } /* Float */
+code > span.ch { color: #4070a0; } /* Char */
+code > span.st { color: #4070a0; } /* String */
+code > span.co { color: #60a0b0; font-style: italic; } /* Comment */
+code > span.ot { color: #007020; } /* Other */
+code > span.al { color: #ff0000; font-weight: bold; } /* Alert */
+code > span.fu { color: #06287e; } /* Function */
+code > span.er { color: #ff0000; font-weight: bold; } /* Error */
+code > span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
+code > span.cn { color: #880000; } /* Constant */
+code > span.sc { color: #4070a0; } /* SpecialChar */
+code > span.vs { color: #4070a0; } /* VerbatimString */
+code > span.ss { color: #bb6688; } /* SpecialString */
+code > span.im { } /* Import */
+code > span.va { color: #19177c; } /* Variable */
+code > span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
+code > span.op { color: #666666; } /* Operator */
+code > span.bu { } /* BuiltIn */
+code > span.ex { } /* Extension */
+code > span.pp { color: #bc7a00; } /* Preprocessor */
+code > span.at { color: #7d9029; } /* Attribute */
+code > span.do { color: #ba2121; font-style: italic; } /* Documentation */
+code > span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
+code > span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
+code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+</style>
+
+
+
+<link href="data:text/css;charset=utf-8,body%20%7B%0Abackground%2Dcolor%3A%20%23fff%3B%0Amargin%3A%201em%20auto%3B%0Amax%2Dwidth%3A%20700px%3B%0Aoverflow%3A%20visible%3B%0Apadding%2Dleft%3A%202em%3B%0Apadding%2Dright%3A%202em%3B%0Afont%2Dfamily%3A%20%22Open%20Sans%22%2C%20%22Helvetica%20Neue%22%2C%20Helvetica%2C%20Arial%2C%20sans%2Dserif%3B%0Afont%2Dsize%3A%2014px%3B%0Aline%2Dheight%3A%201%2E35%3B%0A%7D%0A%23header%20%7B%0Atext%2Dalign%3A%20center%3B%0A%7D%0A%23TOC%20%7B%0Aclear%3A%20both%3B%0Amargin%3A%200%200%2010px%2010px%3B%0Apadding%3A%204px%3B%0Awidth%3A%20400px%3B%0Aborder%3A%201px%20solid%20%23CCCCCC%3B%0Aborder%2Dradius%3A%205px%3B%0Abackground%2Dcolor%3A%20%23f6f6f6%3B%0Afont%2Dsize%3A%2013px%3B%0Aline%2Dheight%3A%201%2E3%3B%0A%7D%0A%23TOC%20%2Etoctitle%20%7B%0Afont%2Dweight%3A%20bold%3B%0Afont%2Dsize%3A%2015px%3B%0Amargin%2Dleft%3A%205px%3B%0A%7D%0A%23TOC%20ul%20%7B%0Apadding%2Dleft%3A%2040px%3B%0Amargin%2Dleft%3A%20%2D1%2E5em%3B%0Amargin%2Dtop%3A%205px%3B%0Amargin%2Dbottom%3A%205px%3B%0A%7D%0A%23TOC%20ul%20ul%20%7B%0Amargin%2Dleft%3A%20%2D2em%3B%0A%7D%0A%23TOC%20li%20%7B%0Aline%2Dheight%3A%2016px%3B%0A%7D%0Atable%20%7B%0Amargin%3A%201em%20auto%3B%0Aborder%2Dwidth%3A%201px%3B%0Aborder%2Dcolor%3A%20%23DDDDDD%3B%0Aborder%2Dstyle%3A%20outset%3B%0Aborder%2Dcollapse%3A%20collapse%3B%0A%7D%0Atable%20th%20%7B%0Aborder%2Dwidth%3A%202px%3B%0Apadding%3A%205px%3B%0Aborder%2Dstyle%3A%20inset%3B%0A%7D%0Atable%20td%20%7B%0Aborder%2Dwidth%3A%201px%3B%0Aborder%2Dstyle%3A%20inset%3B%0Aline%2Dheight%3A%2018px%3B%0Apadding%3A%205px%205px%3B%0A%7D%0Atable%2C%20table%20th%2C%20table%20td%20%7B%0Aborder%2Dleft%2Dstyle%3A%20none%3B%0Aborder%2Dright%2Dstyle%3A%20none%3B%0A%7D%0Atable%20thead%2C%20table%20tr%2Eeven%20%7B%0Abackground%2Dcolor%3A%20%23f7f7f7%3B%0A%7D%0Ap%20%7B%0Amargin%3A%200%2E5em%200%3B%0A%7D%0Ablockquote%20%7B%0Abackground%2Dcolor%3A%20%23f6f6f6%3B%0Apadding%3A%200%2E25em%200%2E75em%3B%0A%7D%0Ahr%20%7B%0Aborder%2Dstyle%3A%20solid%3B%0Aborder%3A%20none%3B%0Aborder%2Dtop%3A%201px%20solid%20%23777%3B%0Amargin%3A%2028px%200%3B%0A%7D%0Adl%20%7B%0Amargin%2Dleft%3A%200%3B%0A%7D%0Adl%20dd%20%7B%0Amargin%2Dbottom%3A%2013px%3B%0Amargin%2Dleft%3A%2013px%3B%0A%7D%0Adl%20dt%20%7B%0Afont%2Dweight%3A%20bold%3B%0A%7D%0Aul%20%7B%0Amargin%2Dtop%3A%200%3B%0A%7D%0Aul%20li%20%7B%0Alist%2Dstyle%3A%20circle%20outside%3B%0A%7D%0Aul%20ul%20%7B%0Amargin%2Dbottom%3A%200%3B%0A%7D%0Apre%2C%20code%20%7B%0Abackground%2Dcolor%3A%20%23f7f7f7%3B%0Aborder%2Dradius%3A%203px%3B%0Acolor%3A%20%23333%3B%0Awhite%2Dspace%3A%20pre%2Dwrap%3B%20%0A%7D%0Apre%20%7B%0Aborder%2Dradius%3A%203px%3B%0Amargin%3A%205px%200px%2010px%200px%3B%0Apadding%3A%2010px%3B%0A%7D%0Apre%3Anot%28%5Bclass%5D%29%20%7B%0Abackground%2Dcolor%3A%20%23f7f7f7%3B%0A%7D%0Acode%20%7B%0Afont%2Dfamily%3A%20Consolas%2C%20Monaco%2C%20%27Courier%20New%27%2C%20monospace%3B%0Afont%2Dsize%3A%2085%25%3B%0A%7D%0Ap%20%3E%20code%2C%20li%20%3E%20code%20%7B%0Apadding%3A%202px%200px%3B%0A%7D%0Adiv%2Efigure%20%7B%0Atext%2Dalign%3A%20center%3B%0A%7D%0Aimg%20%7B%0Abackground%2Dcolor%3A%20%23FFFFFF%3B%0Apadding%3A%202px%3B%0Aborder%3A%201px%20solid%20%23DDDDDD%3B%0Aborder%2Dradius%3A%203px%3B%0Aborder%3A%201px%20solid%20%23CCCCCC%3B%0Amargin%3A%200%205px%3B%0A%7D%0Ah1%20%7B%0Amargin%2Dtop%3A%200%3B%0Afont%2Dsize%3A%2035px%3B%0Aline%2Dheight%3A%2040px%3B%0A%7D%0Ah2%20%7B%0Aborder%2Dbottom%3A%204px%20solid%20%23f7f7f7%3B%0Apadding%2Dtop%3A%2010px%3B%0Apadding%2Dbottom%3A%202px%3B%0Afont%2Dsize%3A%20145%25%3B%0A%7D%0Ah3%20%7B%0Aborder%2Dbottom%3A%202px%20solid%20%23f7f7f7%3B%0Apadding%2Dtop%3A%2010px%3B%0Afont%2Dsize%3A%20120%25%3B%0A%7D%0Ah4%20%7B%0Aborder%2Dbottom%3A%201px%20solid%20%23f7f7f7%3B%0Amargin%2Dleft%3A%208px%3B%0Afont%2Dsize%3A%20105%25%3B%0A%7D%0Ah5%2C%20h6%20%7B%0Aborder%2Dbottom%3A%201px%20solid%20%23ccc%3B%0Afont%2Dsize%3A%20105%25%3B%0A%7D%0Aa%20%7B%0Acolor%3A%20%230033dd%3B%0Atext%2Ddecoration%3A%20none%3B%0A%7D%0Aa%3Ahover%20%7B%0Acolor%3A%20%236666ff%3B%20%7D%0Aa%3Avisited%20%7B%0Acolor%3A%20%23800080%3B%20%7D%0Aa%3Avisited%3Ahover%20%7B%0Acolor%3A%20%23BB00BB%3B%20%7D%0Aa%5Bhref%5E%3D%22http%3A%22%5D%20%7B%0Atext%2Ddecoration%3A%20underline%3B%20%7D%0Aa%5Bhref%5E%3D%22https%3A%22%5D%20%7B%0Atext%2Ddecoration%3A%20underline%3B%20%7D%0A%0Acode%20%3E%20span%2Ekw%20%7B%20color%3A%20%23555%3B%20font%2Dweight%3A%20bold%3B%20%7D%20%0Acode%20%3E%20span%2Edt%20%7B%20color%3A%20%23902000%3B%20%7D%20%0Acode%20%3E%20span%2Edv%20%7B%20color%3A%20%2340a070%3B%20%7D%20%0Acode%20%3E%20span%2Ebn%20%7B%20color%3A%20%23d14%3B%20%7D%20%0Acode%20%3E%20span%2Efl%20%7B%20color%3A%20%23d14%3B%20%7D%20%0Acode%20%3E%20span%2Ech%20%7B%20color%3A%20%23d14%3B%20%7D%20%0Acode%20%3E%20span%2Est%20%7B%20color%3A%20%23d14%3B%20%7D%20%0Acode%20%3E%20span%2Eco%20%7B%20color%3A%20%23888888%3B%20font%2Dstyle%3A%20italic%3B%20%7D%20%0Acode%20%3E%20span%2Eot%20%7B%20color%3A%20%23007020%3B%20%7D%20%0Acode%20%3E%20span%2Eal%20%7B%20color%3A%20%23ff0000%3B%20font%2Dweight%3A%20bold%3B%20%7D%20%0Acode%20%3E%20span%2Efu%20%7B%20color%3A%20%23900%3B%20font%2Dweight%3A%20bold%3B%20%7D%20%20code%20%3E%20span%2Eer%20%7B%20color%3A%20%23a61717%3B%20background%2Dcolor%3A%20%23e3d2d2%3B%20%7D%20%0A" rel="stylesheet" type="text/css" />
+
+</head>
+
+<body>
+
+
+
+
+<h1 class="title toc-ignore">Read text files with readtext()</h1>
+
+
+<div id="TOC">
+<ul>
+<li><a href="#introduction">1. Introduction</a></li>
+<li><a href="#reading-one-or-more-text-files">2. Reading one or more text files</a><ul>
+<li><a href="#plain-text-files-.txt">2.1 Plain text files (.txt)</a></li>
+<li><a href="#comma--or-tab-separated-values-.csv-.tab-.tsv">2.2 Comma- or tab-separated values (.csv, .tab, .tsv)</a></li>
+<li><a href="#json-data-.json">2.3 JSON data (.json)</a></li>
+<li><a href="#pdf-files">2.4 PDF files</a></li>
+<li><a href="#microsoft-word-files-.doc-.docx">2.5 Microsoft Word files (.doc, .docx)</a></li>
+<li><a href="#text-from-urls">2.6 Text from URLs</a></li>
+<li><a href="#text-from-archive-files-.zip-.tar-.tar.gz-.tar.bz">2.7 Text from archive files (.zip, .tar, .tar.gz, .tar.bz)</a></li>
+</ul></li>
+<li><a href="#inter-operability-with-quanteda">3. Inter-operability with quanteda</a></li>
+<li><a href="#solving-common-problems">4. Solving common problems</a><ul>
+<li><a href="#remove-page-numbers-using-regular-expressions">4.1 Remove page numbers using regular expressions</a></li>
+<li><a href="#read-files-with-different-encodings">4.2 Read files with different encodings</a></li>
+</ul></li>
+</ul>
+</div>
+
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Load readtext package</span>
+<span class="kw">library</span>(readtext)</code></pre></div>
+<div id="introduction" class="section level1">
+<h1>1. Introduction</h1>
+<p>The vignette walks you through importing a variety of different text files into R using the <strong>readtext</strong> package. Currently, <strong>readtext</strong> supports plain text files (.txt), data in some form of JavaScript Object Notation (.json), comma-or tab-separated values (.csv, .tab, .tsv), XML documents (.xml), as well as PDF and Microsoft Word formatted files (.pdf, .doc, .docx).</p>
+<p><strong>readtext</strong> also handles multiple files and file types using for instance a “glob” expression, files from a URL or an archive file (.zip, .tar, .tar.gz, .tar.bz). Usually, you do not have to determine the format of the files explicitly – <strong>readtext</strong> takes this information from the file ending.</p>
+<p>The <strong>readtext</strong> package comes with a data directory called <code>extdata</code> that contains examples of all files listed above. In the vignette, we use this data directory.</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Get the data directory from readtext</span>
+DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span class="st">&quot;extdata/&quot;</span>, <span class="dt">package =</span> <span class="st">&quot;readtext&quot;</span>)</code></pre></div>
+<p>The <code>extdata</code> directory contains several subfolders that include different text files. In the following examples, we load one or more files stored in each of these folders. The <code>paste0</code> command is used to concatenate the <code>extdata</code> folder from the <strong>readtext</strong> package with the subfolders. When reading in custom text files, you will need to determine your own data directory (see <code>?setwd()</code>).</p>
+</div>
+<div id="reading-one-or-more-text-files" class="section level1">
+<h1>2. Reading one or more text files</h1>
+<div id="plain-text-files-.txt" class="section level2">
+<h2>2.1 Plain text files (.txt)</h2>
+<p>The folder “txt” contains a subfolder named UDHR with .txt files of the Universal Declaration of Human Rights in 13 languages.</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Read in all files from a folder</span>
+rt_txt_1 &lt;-<span class="st"> </span><span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;txt/UDHR/*&quot;</span>))
+<span class="kw">str</span>(rt_txt_1)</code></pre></div>
+<pre><code>## Classes 'readtext' and 'data.frame': 13 obs. of  1 variable:
+##  $ text: chr  &quot;世界人权宣言\n联合国大会一九四八年十二月十日第217A(III)号决议通过并颁布 1948 年 12 月 10 日， 联 合 国 大 会 通 过 并 颁 布《 &quot;| __truncated__ &quot;VŠEOBECNÁ DEKLARACE LIDSKÝCH PRÁV\nÚvod U vědomí toho, že uznání přirozené důstojnosti a rovných a nezcizitelných práv členů li&quot;| __truncated__ &quot;Den 10. december 1948 vedtog og offentliggjorde FNs tredie generalforsamling Verdenserklæringen om Menneskerettighederne. Erklæ&quot;| __truncated__ &quot;Universal Declaration of Human Rights\nPreamble Whereas recognition of the inherent dignity and of the equal and inalienable ri&quot;| __truncated__ ...</code></pre>
+<p>We can specify document-level metadata (<code>docvars</code>) based on the file names or on a separate data.frame. Below we take the docvars from the filenames (<code>docvarsfrom = &quot;filenames&quot;</code>) and set the names for each variable (<code>docvarnames = c(&quot;unit&quot;, &quot;context&quot;, &quot;year&quot;, &quot;language&quot;, &quot;party&quot;)</code>). The command <code>dvsep = &quot;_&quot;</code> determines the separator (a regular expression character string) included in the filenames to delimit the <code>docvar</code> elements.</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Manifestos with docvars from filenames</span>
+rt_txt_2 &lt;-<span class="st"> </span><span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;txt/EU_manifestos/*.txt&quot;</span>),
+                <span class="dt">docvarsfrom =</span> <span class="st">&quot;filenames&quot;</span>, 
+                <span class="dt">docvarnames =</span> <span class="kw">c</span>(<span class="st">&quot;unit&quot;</span>, <span class="st">&quot;context&quot;</span>, <span class="st">&quot;year&quot;</span>, <span class="st">&quot;language&quot;</span>, <span class="st">&quot;party&quot;</span>),
+                <span class="dt">dvsep =</span> <span class="st">&quot;_&quot;</span>)
+
+<span class="kw">str</span>(rt_txt_2)</code></pre></div>
+<pre><code>## Classes 'readtext' and 'data.frame': 18 obs. of  6 variables:
+##  $ text    : chr  &quot;PES \xb7 PSE \xb7 SPE European Parliament rue Wiertz B 1047 Brussels\n\nGEMEINSAM WERDEN WIR ST\xc4RKER F\xfcnf Verpflichtungen&quot;| __truncated__ &quot;Gemeinsames Manifest\nGemeinsames Manifest zur Europawahl 2004 Europ\xe4ischen F\xf6deration Gr\xfcner Parteien (EFGP) \nVerabs&quot;| __truncated__ &quot;PES \xb7 PSE \xb7 SPE European Parliament rue Wiertz B 1047 Brussels\n\nGROWING STRONGER TOGETHER Five commitments for the next&quot;| __truncated__ &quot;Manifesto\nEuropean Elections Manifesto 2004\nCOMMON PREAMBLE\nAs adopted at 15th EFGP Council, Luxembourg, 8th November 2003\n&quot;| __truncated__ ...
+##  $ unit    : chr  &quot;EU&quot; &quot;EU&quot; &quot;EU&quot; &quot;EU&quot; ...
+##  $ context : chr  &quot;euro&quot; &quot;euro&quot; &quot;euro&quot; &quot;euro&quot; ...
+##  $ year    : int  2004 2004 2004 2004 2004 2004 2004 2004 2004 2004 ...
+##  $ language: chr  &quot;de&quot; &quot;de&quot; &quot;en&quot; &quot;en&quot; ...
+##  $ party   : chr  &quot;PSE&quot; &quot;V&quot; &quot;PSE&quot; &quot;V&quot; ...</code></pre>
+<p><strong>readtext</strong> can also curse through subdirectories. In our example, the folder <code>txt/movie_reviews</code> contains two subfolders (called <code>neg</code> and <code>pos</code>). We can load all texts included in both folders.</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Recurse through subdirectories</span>
+rt_txt_3 &lt;-<span class="st"> </span><span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;txt/movie_reviews/*&quot;</span>))
+<span class="kw">str</span>(rt_txt_3)</code></pre></div>
+<pre><code>## Classes 'readtext' and 'data.frame': 100 obs. of  1 variable:
+##  $ text: chr  &quot;plot : two teen couples go to a church party , drink and then drive . \nthey get into an accident . \none of the guys dies , bu&quot;| __truncated__ &quot;the happy bastard's quick movie review \ndamn that y2k bug . \nit's got a head start in this movie starring jamie lee curtis an&quot;| __truncated__ &quot;it is movies like these that make a jaded movie viewer thankful for the invention of the timex indiglo watch . \nbased on the l&quot;| __truncated__ &quot; \&quot; quest for camelot \&quot; is warner bros . ' first feature-length , fully-animated attempt to steal clout from disney's cartoon &quot;| __truncated__ ...</code></pre>
+</div>
+<div id="comma--or-tab-separated-values-.csv-.tab-.tsv" class="section level2">
+<h2>2.2 Comma- or tab-separated values (.csv, .tab, .tsv)</h2>
+<p>Read in comma separted values (.csv files) that contain textual data. We determine the <code>texts</code> variable in our .csv file as the <code>textfield</code>. This is the column that contains the actual text. The other columns of the original csv file (<code>Year</code>, <code>President</code>, <code>FirstName</code>) are by default treated as document-level variables.</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Read in comma-separated values</span>
+rt_csv &lt;-<span class="st"> </span><span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;csv/inaugCorpus.csv&quot;</span>), <span class="dt">textfield =</span> <span class="st">&quot;texts&quot;</span>)
+<span class="kw">str</span>(rt_csv)</code></pre></div>
+<pre><code>## Classes 'readtext' and 'data.frame': 5 obs. of  4 variables:
+##  $ text     : chr  &quot;Fellow-Citizens of the Senate and of the House of Representatives:\n\nAmong the vicissitudes incident to life no event could ha&quot;| __truncated__ &quot;Fellow citizens, I am again called upon by the voice of my country to execute the functions of its Chief Magistrate. When the o&quot;| __truncated__ &quot;When it was first perceived, in early times, that no middle course for America remained between unlimited submission to a forei&quot;| __truncated__ &quot;Friends and Fellow Citizens:\n\nCalled upon to undertake the duties of the first executive office of our country, I avail mysel&quot;| __truncated__ ...
+##  $ Year     : int  1789 1793 1797 1801 1805
+##  $ President: chr  &quot;Washington&quot; &quot;Washington&quot; &quot;Adams&quot; &quot;Jefferson&quot; ...
+##  $ FirstName: chr  &quot;George&quot; &quot;George&quot; &quot;John&quot; &quot;Thomas&quot; ...</code></pre>
+<p>The same procedure applies to tab-separated values.</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Read in tab-separated values</span>
+rt_tsv &lt;-<span class="st"> </span><span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;tsv/dailsample.tsv&quot;</span>), <span class="dt">textfield =</span> <span class="st">&quot;speech&quot;</span>)
+<span class="kw">str</span>(rt_tsv)</code></pre></div>
+<pre><code>## Classes 'readtext' and 'data.frame': 33 obs. of  10 variables:
+##  $ text       : chr  &quot;Molaimse don Dáil Cathal Brugha, an Teachta ó Dhéisibh Phortláirge do bheith mar Cheann Comhairle againn indiu.&quot; &quot;Is bród mór damhsa cur leis an dtairgsin sin. Air sin do ghaibh CATHAL BRUGHA ceannus na Dála agus adubhairt:-&quot; &quot;' A cháirde, tá obair thábhachtach le déanamh annso indiu, an obair is tábhachtaighe do rinneadh in Éirinn ón lá tháinic na Gae&quot;| __truncated__ &quot;Tá ceathrar cléireach uainn I gcóir gnótha an lae, agus molaim díbh - Diarmuid Ó hÉigeartaigh, Riseárd Ó Foghludha, Seán Ó Núná&quot;| __truncated__ ...
+##  $ speechID   : int  1 2 3 4 5 6 7 8 9 10 ...
+##  $ memberID   : int  977 1603 116 116 116 116 496 116 116 2095 ...
+##  $ partyID    : int  22 22 22 22 22 22 22 22 22 22 ...
+##  $ constID    : int  158 103 178 178 178 178 46 178 178 139 ...
+##  $ title      : chr  &quot;1. CEANN COMHAIRLE I gCOIR AN LAE.&quot; &quot;1. CEANN COMHAIRLE I gCOIR AN LAE.&quot; &quot;1. CEANN COMHAIRLE I gCOIR AN LAE.&quot; &quot;2. CLEIRIGH I gCOIR AN LAE.&quot; ...
+##  $ date       : chr  &quot;1919-01-21&quot; &quot;1919-01-21&quot; &quot;1919-01-21&quot; &quot;1919-01-21&quot; ...
+##  $ member_name: chr  &quot;Count George Noble, Count Plunkett&quot; &quot;Mr. Pádraic Ó Máille&quot; &quot;Mr. Cathal Brugha&quot; &quot;Mr. Cathal Brugha&quot; ...
+##  $ party_name : chr  &quot;Sinn Féin&quot; &quot;Sinn Féin&quot; &quot;Sinn Féin&quot; &quot;Sinn Féin&quot; ...
+##  $ const_name : chr  &quot;Roscommon North&quot; &quot;Galway Connemara&quot; &quot;Waterford County&quot; &quot;Waterford County&quot; ...</code></pre>
+</div>
+<div id="json-data-.json" class="section level2">
+<h2>2.3 JSON data (.json)</h2>
+<p>You can also read .json data. Again you need to specify the <code>textfield</code>.</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">## Read in JSON data
+rt_json &lt;-<span class="st"> </span><span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;json/inaugural_sample.json&quot;</span>), <span class="dt">textfield =</span> <span class="st">&quot;texts&quot;</span>)</code></pre></div>
+<pre><code>## Warning in doTryCatch(return(expr), name, parentenv, handler): Doesn't look
+## like Tweets json file, trying general JSON</code></pre>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">str</span>(rt_json)</code></pre></div>
+<pre><code>## Classes 'readtext' and 'data.frame': 3 obs. of  4 variables:
+##  $ text     : chr  &quot;Fellow-Citizens of the Senate and of the House of Representatives:\n\nAmong the vicissitudes incident to life no event could ha&quot;| __truncated__ &quot;Fellow citizens, I am again called upon by the voice of my country to execute the functions of its Chief Magistrate. When the o&quot;| __truncated__ &quot;When it was first perceived, in early times, that no middle course for America remained between unlimited submission to a forei&quot;| __truncated__
+##  $ Year     : int  1789 1793 1797
+##  $ President: chr  &quot;Washington&quot; &quot;Washington&quot; &quot;Adams&quot;
+##  $ FirstName: chr  &quot;George&quot; &quot;George&quot; &quot;John&quot;</code></pre>
+</div>
+<div id="pdf-files" class="section level2">
+<h2>2.4 PDF files</h2>
+<p><strong>readtext</strong> can also read in .pdf files after converting them through <code>pdftotext</code>. In older versions this required <code>xpdf</code> to be installed, either through <code>brew install xpdf</code> (macOS; see extensively <a href="https://brew.sh" class="uri">https://brew.sh</a>) or from <a href="http://www.winfield.demon.nl" class="uri">http://www.winfield.demon.nl</a> (Windows). Note that the most recent version of <strong>readtext</strong> should install this software automatically.</p>
+<p>In the example below we load all .pdf files stored in the <code>UDHR</code> folder, and determine that the <code>docvars</code> shall be taken from the filenames. We call the document-level variables <code>document</code> and <code>language</code>, and specify the delimiter (<code>dvsep</code>).</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">## Read in Universal Declaration of Human Rights pdf files
+rt_pdf &lt;-<span class="st"> </span><span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;pdf/UDHR/*.pdf&quot;</span>), 
+                <span class="dt">docvarsfrom =</span> <span class="st">&quot;filenames&quot;</span>, 
+                <span class="dt">docvarnames =</span> <span class="kw">c</span>(<span class="st">&quot;document&quot;</span>, <span class="st">&quot;language&quot;</span>),
+                <span class="dt">sep =</span> <span class="st">&quot;_&quot;</span>)
+<span class="kw">str</span>(rt_pdf)</code></pre></div>
+<pre><code>## Classes 'readtext' and 'data.frame': 11 obs. of  3 variables:
+##  $ text    : chr  &quot;世界人权宣言\n联合国大会一九四八年十二月十日第217A(III)号决议通过并颁布\n1948 年 12 月 10 日， 联 合 国 大 会 通 过 并 颁 布《 &quot;| __truncated__ &quot;VŠEOBECNÁ DEKLARACE LIDSKÝCH PRÁV\nÚvod\nU vědomí toho,\nže uznání přirozené důstojnosti a rovných a nezcizitelných práv členů &quot;| __truncated__ &quot;Den 10. december 1948 vedtog og offentliggjorde FNs tredie generalforsamling\nVerdenserklæringen om Menneskerettighederne. Erkl&quot;| __truncated__ &quot;Universal Declaration of Human Rights\nPreamble\nWhereas recognition of the inherent dignity and of the equal and inalienable\n&quot;| __truncated__ ...
+##  $ document: chr  &quot;UDHR&quot; &quot;UDHR&quot; &quot;UDHR&quot; &quot;UDHR&quot; ...
+##  $ language: chr  &quot;chinese&quot; &quot;czech&quot; &quot;danish&quot; &quot;english&quot; ...</code></pre>
+<p>We can always check the encoding of each file.</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">Encoding</span>(rt_pdf$text)</code></pre></div>
+<pre><code>##  [1] &quot;UTF-8&quot;   &quot;UTF-8&quot;   &quot;UTF-8&quot;   &quot;unknown&quot; &quot;UTF-8&quot;   &quot;UTF-8&quot;   &quot;UTF-8&quot;  
+##  [8] &quot;UTF-8&quot;   &quot;UTF-8&quot;   &quot;UTF-8&quot;   &quot;UTF-8&quot;</code></pre>
+</div>
+<div id="microsoft-word-files-.doc-.docx" class="section level2">
+<h2>2.5 Microsoft Word files (.doc, .docx)</h2>
+<p>Microsoft Word formatted files are converted through <code>antiword</code>. In older versions you might need to install <code>antiword</code> either through <code>brew install antiword</code> (macOS; see extensively <a href="https://brew.sh" class="uri">https://brew.sh</a>) or from <a href="http://www.winfield.demon.nl" class="uri">http://www.winfield.demon.nl</a> (Windows). Again, the most recent version of <strong>readtext</strong> should install <code>antiword</code> by default. If it is not working try:</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">install.packages</span>(<span class="st">&quot;antiword&quot;</span>)
+<span class="kw">require</span>(antiword)</code></pre></div>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">## Read in Word data (.docx)
+rt_docx &lt;-<span class="st"> </span><span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;word/*.docx&quot;</span>))
+
+<span class="kw">str</span>(rt_docx)</code></pre></div>
+<pre><code>## Classes 'readtext' and 'data.frame': 2 obs. of  1 variable:
+##  $ text: chr  &quot;The Eccentric Party\nElection Manifesto 2015\nPOLICIES:\u2028iPads, smartphones, X-boxes etc will come with a slot metre to red&quot;| __truncated__ &quot;The Official Monster Raving Loony Party\n2015 Election Manicfesto\n20150219\nThe A-Z of the OMRLP Manicfesto Just a sample of w&quot;| __truncated__</code></pre>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">Encoding</span>(rt_docx$text)</code></pre></div>
+<pre><code>## [1] &quot;UTF-8&quot; &quot;UTF-8&quot;</code></pre>
+</div>
+<div id="text-from-urls" class="section level2">
+<h2>2.6 Text from URLs</h2>
+<p>You can also read in text directly from a URL.</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Note: Example required -- which URL should we use?</span></code></pre></div>
+</div>
+<div id="text-from-archive-files-.zip-.tar-.tar.gz-.tar.bz" class="section level2">
+<h2>2.7 Text from archive files (.zip, .tar, .tar.gz, .tar.bz)</h2>
+<p>Finally, it is possible to inclue text from archives.</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Note: Archive file required. The only zip archive included in readtext has </span>
+<span class="co"># different encodings and is difficult to import (see section 4.2).</span></code></pre></div>
+</div>
+</div>
+<div id="inter-operability-with-quanteda" class="section level1">
+<h1>3. Inter-operability with quanteda</h1>
+<p><strong>readtext</strong> was originally developed in early versions of the <a href="https://github.com/kbenoit/quanteda"><strong>quanteda</strong></a> package for the quantitative analysis of textual data. It was spawned from the <code>textfile()</code> function from that package, and now lives exclusively in <strong>readtext</strong>. Because <strong>quanteda</strong>’s corpus constructor recognizes the data.frame format returned by <code>readtext()</code>, it can construct a corpus directly from a <code>readtext</code> object, preserving all docvars and other meta-data.</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">require</span>(quanteda)</code></pre></div>
+<p>You can easily contruct a corpus from a <strong>readtext</strong> object.</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Read in comma-separated values with readtext</span>
+rt_csv &lt;-<span class="st"> </span><span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;csv/inaugCorpus.csv&quot;</span>), <span class="dt">textfield =</span> <span class="st">&quot;texts&quot;</span>)
+
+<span class="co"># Create quanteda corpus</span>
+corpus_csv &lt;-<span class="st"> </span>quanteda::<span class="kw">corpus</span>(rt_csv)
+
+<span class="kw">summary</span>(corpus_csv, <span class="dv">5</span>)</code></pre></div>
+<pre><code>## Corpus consisting of 5 documents.
+## 
+##               Text Types Tokens Sentences Year  President FirstName
+##  inaugCorpus.csv.1   626   1542        23 1789 Washington    George
+##  inaugCorpus.csv.2    96    147         4 1793 Washington    George
+##  inaugCorpus.csv.3   826   2584        37 1797      Adams      John
+##  inaugCorpus.csv.4   716   1935        41 1801  Jefferson    Thomas
+##  inaugCorpus.csv.5   804   2381        45 1805  Jefferson    Thomas
+## 
+## Source:  /Users/stefan/GitHub/vignettes/* on x86_64 by stefan
+## Created: Tue Apr 25 19:59:28 2017
+## Notes:</code></pre>
+</div>
+<div id="solving-common-problems" class="section level1">
+<h1>4. Solving common problems</h1>
+<div id="remove-page-numbers-using-regular-expressions" class="section level2">
+<h2>4.1 Remove page numbers using regular expressions</h2>
+<p>When a document contains page numbers, they are imported as well. If you want to remove them, you can use a regular expression. We strongly recommend using the <a href="https://github.com/gagolews/stringi"><strong>stringi</strong></a> package. For the most common regular expressions you can look at this <a href="http://web.mit.edu/hackl/www/lab/turkshop/slides/regex-cheatsheet.pdf">cheatsheet</a>.</p>
+<p>You first need to check in the original file in which format the page numbers occur (e.g., “1”, “-1-”, “page 1” etc.). We can make use of the fact that page numbers are almost always preceded and followed by a linebreak (<code>\n</code>). After loading the text with <strong>readtext</strong>, you can replace the page numbers.</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Load stringi package</span>
+<span class="kw">require</span>(stringi)</code></pre></div>
+<p>In the first example, the page numbers have the format “page X”.</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Make some text with page numbers</span>
+sample_text_a &lt;-<span class="st"> &quot;The quick brown fox named Seamus jumps over the lazy dog also named Seamus, </span>
+<span class="st">page 1 </span>
+<span class="st">with the newspaper from a boy named quick Seamus, in his mouth.</span>
+<span class="st">page 2</span>
+<span class="st">The quicker brown fox jumped over 2 lazy dogs.&quot;</span>
+
+sample_text_a</code></pre></div>
+<pre><code>## [1] &quot;The quick brown fox named Seamus jumps over the lazy dog also named Seamus, \npage 1 \nwith the newspaper from a boy named quick Seamus, in his mouth.\npage 2\nThe quicker brown fox jumped over 2 lazy dogs.&quot;</code></pre>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Remove &quot;page&quot; and respective digit</span>
+sample_text_a2 &lt;-<span class="st"> </span><span class="kw">unlist</span>(<span class="kw">stri_split_fixed</span>(sample_text_a, <span class="st">'</span><span class="ch">\n</span><span class="st">'</span>), <span class="dt">use.names =</span> <span class="ot">FALSE</span>)
+sample_text_a2 &lt;-<span class="st"> </span><span class="kw">stri_replace_all_regex</span>(sample_text_a2, <span class="st">&quot;page </span><span class="ch">\\</span><span class="st">d*&quot;</span>, <span class="st">&quot;&quot;</span>)
+sample_text_a2 &lt;-<span class="st"> </span><span class="kw">stri_trim_both</span>(sample_text_a2)
+sample_text_a2 &lt;-<span class="st"> </span>sample_text_a2[sample_text_a2 !=<span class="st"> ''</span>]
+<span class="kw">stri_paste</span>(sample_text_a2, <span class="dt">collapse =</span> <span class="st">'</span><span class="ch">\n</span><span class="st">'</span>)</code></pre></div>
+<pre><code>## [1] &quot;The quick brown fox named Seamus jumps over the lazy dog also named Seamus,\nwith the newspaper from a boy named quick Seamus, in his mouth.\nThe quicker brown fox jumped over 2 lazy dogs.&quot;</code></pre>
+<p>In the second example we remove page numbers which have the format “- X -”.</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">sample_text_b &lt;-<span class="st"> &quot;The quick brown fox named Seamus </span>
+<span class="st">- 1 - </span>
+<span class="st">jumps over the lazy dog also named Seamus, with </span>
+<span class="st">- 2 - </span>
+<span class="st">the newspaper from a boy named quick Seamus, in his mouth. </span>
+<span class="st">- 33 - </span>
+<span class="st">The quicker brown fox jumped over 2 lazy dogs.&quot;</span>
+
+sample_text_b</code></pre></div>
+<pre><code>## [1] &quot;The quick brown fox named Seamus \n- 1 - \njumps over the lazy dog also named Seamus, with \n- 2 - \nthe newspaper from a boy named quick Seamus, in his mouth. \n- 33 - \nThe quicker brown fox jumped over 2 lazy dogs.&quot;</code></pre>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">sample_text_b2 &lt;-<span class="st"> </span><span class="kw">unlist</span>(<span class="kw">stri_split_fixed</span>(sample_text_b, <span class="st">'</span><span class="ch">\n</span><span class="st">'</span>), <span class="dt">use.names =</span> <span class="ot">FALSE</span>)
+sample_text_b2 &lt;-<span class="st"> </span><span class="kw">stri_replace_all_regex</span>(sample_text_b2, <span class="st">&quot;[-] </span><span class="ch">\\</span><span class="st">d* [-]&quot;</span>, <span class="st">&quot;&quot;</span>)
+sample_text_b2 &lt;-<span class="st"> </span><span class="kw">stri_trim_both</span>(sample_text_b2)
+sample_text_b2 &lt;-<span class="st"> </span>sample_text_b2[sample_text_b2 !=<span class="st"> ''</span>]
+<span class="kw">stri_paste</span>(sample_text_b2, <span class="dt">collapse =</span> <span class="st">'</span><span class="ch">\n</span><span class="st">'</span>)</code></pre></div>
+<pre><code>## [1] &quot;The quick brown fox named Seamus\njumps over the lazy dog also named Seamus, with\nthe newspaper from a boy named quick Seamus, in his mouth.\nThe quicker brown fox jumped over 2 lazy dogs.&quot;</code></pre>
+<p>Such <strong>stringi</strong> functions can also be applied to <strong>readtext</strong> objects.</p>
+</div>
+<div id="read-files-with-different-encodings" class="section level2">
+<h2>4.2 Read files with different encodings</h2>
+<p>Sometimes files of the same type have different encodings. If the encoding of a file is included in the file name, we can extract this information and import the texts correctly.</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Create a temporary directory to extract the .zip file</span>
+FILEDIR &lt;-<span class="st"> </span><span class="kw">tempdir</span>()
+
+<span class="co"># Unzip file</span>
+<span class="kw">unzip</span>(<span class="kw">system.file</span>(<span class="st">&quot;extdata&quot;</span>, <span class="st">&quot;data_files_encodedtexts.zip&quot;</span>, <span class="dt">package =</span> <span class="st">&quot;readtext&quot;</span>), <span class="dt">exdir =</span> FILEDIR)</code></pre></div>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Get encoding from filename</span>
+filenames &lt;-<span class="st"> </span><span class="kw">list.files</span>(FILEDIR, <span class="st">&quot;</span><span class="ch">\\</span><span class="st">.txt$&quot;</span>)
+
+<span class="kw">head</span>(filenames)</code></pre></div>
+<pre><code>## [1] &quot;IndianTreaty_English_UTF-16LE.txt&quot; 
+## [2] &quot;IndianTreaty_English_UTF-8-BOM.txt&quot;
+## [3] &quot;UDHR_Arabic_ISO-8859-6.txt&quot;        
+## [4] &quot;UDHR_Arabic_MACARABIC.txt&quot;         
+## [5] &quot;UDHR_Arabic_UTF-8.txt&quot;             
+## [6] &quot;UDHR_Arabic_WINDOWS-1256.txt&quot;</code></pre>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Strip the extension</span>
+filenames &lt;-<span class="st"> </span><span class="kw">gsub</span>(<span class="st">&quot;.txt$&quot;</span>, <span class="st">&quot;&quot;</span>, filenames)
+parts &lt;-<span class="st"> </span><span class="kw">strsplit</span>(filenames, <span class="st">&quot;_&quot;</span>)
+fileencodings &lt;-<span class="st"> </span><span class="kw">sapply</span>(parts, <span class="st">&quot;[&quot;</span>, <span class="dv">3</span>)
+
+<span class="kw">head</span>(fileencodings)</code></pre></div>
+<pre><code>## [1] &quot;UTF-16LE&quot;     &quot;UTF-8-BOM&quot;    &quot;ISO-8859-6&quot;   &quot;MACARABIC&quot;   
+## [5] &quot;UTF-8&quot;        &quot;WINDOWS-1256&quot;</code></pre>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Check whether certain file encodings are not supported</span>
+notAvailableIndex &lt;-<span class="st"> </span><span class="kw">which</span>(!(fileencodings %in%<span class="st"> </span><span class="kw">iconvlist</span>()))
+fileencodings[notAvailableIndex]</code></pre></div>
+<pre><code>## [1] &quot;UTF-8-BOM&quot;</code></pre>
+<p>If we read the text files without specifying the encoding, we get errendously formatted text. To avoid this, we determine the <code>encoding</code> using the character object <code>fileencoding</code> created above.</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Read txt files</span>
+txts &lt;-<span class="st"> </span><span class="kw">readtext</span>(<span class="kw">paste0</span>(FILEDIR,  <span class="st">&quot;/&quot;</span>, <span class="st">&quot;*.txt&quot;</span>), <span class="dt">encoding =</span> fileencodings)
+
+<span class="kw">substring</span>(<span class="kw">texts</span>(txts)[<span class="dv">1</span>], <span class="dv">1</span>, <span class="dv">40</span>)  <span class="co"># English, looking good</span></code></pre></div>
+<pre><code>##          IndianTreaty_English_UTF-16LE.txt 
+## &quot;WHEREAS, the Sisseton and Wahpeton Bands&quot;</code></pre>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">substring</span>(<span class="kw">texts</span>(txts)[<span class="dv">4</span>], <span class="dv">1</span>, <span class="dv">40</span>)  <span class="co"># Arabic, looking good </span></code></pre></div>
+<pre><code>##                   UDHR_Arabic_MACARABIC.txt 
+## &quot;الديباجة\nلما كان الاعتراف بالكرامة المتأ&quot;</code></pre>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">substring</span>(<span class="kw">texts</span>(txts)[<span class="dv">40</span>], <span class="dv">1</span>, <span class="dv">40</span>) <span class="co"># Cyrillic, looking good</span></code></pre></div>
+<pre><code>##               UDHR_Russian_WINDOWS-1251.txt 
+## &quot;Всеобщая декларация прав человека\nПринят&quot;</code></pre>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">substring</span>(<span class="kw">texts</span>(txts)[<span class="dv">7</span>], <span class="dv">1</span>, <span class="dv">40</span>)  <span class="co"># Chinese, looking good</span></code></pre></div>
+<pre><code>##                                                   UDHR_Chinese_GB2312.txt 
+## &quot;世界人权宣言\n联合国大会一九四八年十二月十日第217A(III)号决议通过并颁布&quot;</code></pre>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">substring</span>(<span class="kw">texts</span>(txts)[<span class="dv">26</span>], <span class="dv">1</span>, <span class="dv">40</span>) <span class="co"># Hindi, looking good</span></code></pre></div>
+<pre><code>##                       UDHR_Hindi_UTF-8.txt 
+## &quot;मानव अधिकारों की सार्वभौम घोषणा\n\n१० दिसम&quot;</code></pre>
+<p>Again, we can add <code>docvars</code> based on the filenames.</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">txts &lt;-<span class="st"> </span><span class="kw">readtext</span>(<span class="kw">paste0</span>(FILEDIR, <span class="st">&quot;/&quot;</span>, <span class="st">&quot;*.txt&quot;</span>), 
+                 <span class="dt">encoding =</span> fileencodings,
+                 <span class="dt">docvarsfrom =</span> <span class="st">&quot;filenames&quot;</span>, 
+                 <span class="dt">docvarnames =</span> <span class="kw">c</span>(<span class="st">&quot;document&quot;</span>, <span class="st">&quot;language&quot;</span>, <span class="st">&quot;input_encoding&quot;</span>))</code></pre></div>
+<p>From this file we can easily create a <strong>quanteda</strong> <code>corpus</code> object.</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">corpus_txts &lt;-<span class="st"> </span><span class="kw">corpus</span>(txts)
+
+<span class="kw">summary</span>(corpus_txts, <span class="dv">5</span>)</code></pre></div>
+<pre><code>## Corpus consisting of 41 documents, showing 5 documents.
+## 
+##                                Text Types Tokens Sentences     document
+##   IndianTreaty_English_UTF-16LE.txt   690   2938       155 IndianTreaty
+##  IndianTreaty_English_UTF-8-BOM.txt   646   3104       154 IndianTreaty
+##          UDHR_Arabic_ISO-8859-6.txt   753   1555        86         UDHR
+##           UDHR_Arabic_MACARABIC.txt   753   1555        86         UDHR
+##               UDHR_Arabic_UTF-8.txt   753   1555        86         UDHR
+##  language input_encoding
+##   English       UTF-16LE
+##   English      UTF-8-BOM
+##    Arabic     ISO-8859-6
+##    Arabic      MACARABIC
+##    Arabic          UTF-8
+## 
+## Source:  /Users/stefan/GitHub/vignettes/* on x86_64 by stefan
+## Created: Tue Apr 25 19:59:29 2017
+## Notes:</code></pre>
+</div>
+</div>
+
+
+
+<!-- dynamically load mathjax for compatibility with self-contained -->
+<script>
+  (function () {
+    var script = document.createElement("script");
+    script.type = "text/javascript";
+    script.src  = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
+    document.getElementsByTagName("head")[0].appendChild(script);
+  })();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
This adds a folder `vignettes` which contains a **readtext** vignette. It is based both on `?readtext`, `README.Rmd` and own amendments. Please have a look whether there are better **stringi** solutions to remove page numbers based on a regular expression. Excluding page numbers is a common question, so I came up with two typical examples. 