### PR TITLE
Dev text field

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: readtext
-Version: 0.31
+Version: 0.32
 Type: Package
 Title: Import and Handling for Plain and Formatted Text Files
 Authors@R: c( person("Kenneth", "Benoit", email = "kbenoit@lse.ac.uk", role =

--- a/R/get-functions.R
+++ b/R/get-functions.R
@@ -11,7 +11,7 @@ get_txt <- function(f, ...) {
 
 
 ## csv format
-get_csv <- function(path, textfield, ...) {
+get_csv <- function(path, text_field, ...) {
 
 
     args <- list(...)
@@ -34,15 +34,15 @@ get_csv <- function(path, textfield, ...) {
     }
     docs <- do.call(data.table::fread, args)
 
-    if (is.character(textfield)) {
-        textfieldi <- which(names(docs) == textfield)
-        if (length(textfieldi) == 0)
-            stop(paste("There is no field called", textfield, "in file", path))
-        textfield <- textfieldi
-    } else if (is.numeric(textfield) & (textfield > ncol(docs))) {
-        stop(paste0("There is no ", textfield, "th field in file ", path))
+    if (is.character(text_field)) {
+        text_fieldi <- which(names(docs) == text_field)
+        if (length(text_fieldi) == 0)
+            stop(paste("There is no field called", text_field, "in file", path))
+        text_field <- text_fieldi
+    } else if (is.numeric(text_field) & (text_field > ncol(docs))) {
+        stop(paste0("There is no ", text_field, "th field in file ", path))
     }
-    data.frame(text = docs[, textfield], docs[, -textfield, drop = FALSE],
+    data.frame(text = docs[, text_field], docs[, -text_field, drop = FALSE],
                stringsAsFactors = FALSE)
 }
 
@@ -50,7 +50,7 @@ get_csv <- function(path, textfield, ...) {
 
 #  Dispatch to get_json_object or get_json_tweets depending on whether 
 #  it looks like a twitter json file
-get_json <- function(path, textfield, encoding, ...) {
+get_json <- function(path, text_field, encoding, ...) {
     # encoding param is not used
     stopifnot(file.exists(path))
     tryCatch({
@@ -59,14 +59,14 @@ get_json <- function(path, textfield, encoding, ...) {
     error = function(e) {
         tryCatch({
             if (options('readtext_verbosity')[[1]] >= 1) warning("Doesn't look like Tweets json file, trying general JSON")
-            return(get_json_object(path, textfield, ...))
+            return(get_json_object(path, text_field, ...))
         },
         error = function(e) {
-            if (e == paste("There is no field called", textfield, "in file", path)) {
+            if (e == paste("There is no field called", text_field, "in file", path)) {
                 stop(e)
             }
             if (options('readtext_verbosity')[[1]] >= 1) warning("File doesn't contain a single valid JSON object, trying line-delimited json")
-            return(get_json_lines(path, textfield, ...))
+            return(get_json_lines(path, text_field, ...))
         })
     })
     
@@ -87,29 +87,29 @@ get_json_tweets <- function(path, source="twitter", ...) {
 
 ## general json
 #' @importFrom data.table setDT
-get_json_object <- function(path, textfield, ...) {
+get_json_object <- function(path, text_field, ...) {
     if (!requireNamespace("jsonlite", quietly = TRUE))
         stop("You must have jsonlite installed to read json files.")
-    if (is.numeric(textfield)) {
-        stop('Cannot use numeric textfield with json file')
+    if (is.numeric(text_field)) {
+        stop('Cannot use numeric text_field with json file')
     }
     
     docs <- jsonlite::fromJSON(path, flatten=TRUE, ...)
     docs <- data.table::setDT(docs)
-    if (!(textfield %in% colnames(docs))) {
-        stop(paste("There is no field called", textfield, "in file", path))
+    if (!(text_field %in% colnames(docs))) {
+        stop(paste("There is no field called", text_field, "in file", path))
     }
     
-    data.frame(text = docs[[textfield]], docs[, -textfield, with = FALSE],
+    data.frame(text = docs[[text_field]], docs[, -text_field, with = FALSE],
                stringsAsFactors = FALSE)
 }
 
 #' @importFrom data.table rbindlist
-get_json_lines <- function(path, textfield, ...) {
+get_json_lines <- function(path, text_field, ...) {
     if (!requireNamespace("jsonlite", quietly = TRUE))
         stop("You must have jsonlite installed to read json files.")
-    if (is.numeric(textfield)) {
-        stop('Cannot use numeric textfield with json file')
+    if (is.numeric(text_field)) {
+        stop('Cannot use numeric text_field with json file')
     }
     
     lines <- readLines(path, warn = FALSE)
@@ -119,49 +119,49 @@ get_json_lines <- function(path, textfield, ...) {
         use.names = TRUE, fill = TRUE
     )
     
-    if (!(textfield %in% colnames(docs))) {
-        stop(paste("There is no field called", textfield, "in file", path))
+    if (!(text_field %in% colnames(docs))) {
+        stop(paste("There is no field called", text_field, "in file", path))
     }
     
-    data.frame(text = docs[[textfield]], docs[, -textfield, with = FALSE],
+    data.frame(text = docs[[text_field]], docs[, -text_field, with = FALSE],
                stringsAsFactors = FALSE)
 }
 
 
 ## flat xml format
-get_xml <- function(path, textfield, encoding,...) {
+get_xml <- function(path, text_field, encoding,...) {
     # TODO: encoding param is ignored
     if (!requireNamespace("XML", quietly = TRUE))
         stop("You must have XML installed to read XML files.")
     
-    if (is_probably_xpath(textfield))  {
+    if (is_probably_xpath(text_field))  {
         xml <- XML::xmlTreeParse(path, useInternalNodes = TRUE)
-        txt <- XML::xpathApply(xml, textfield, XML::xmlValue, ...)
+        txt <- XML::xpathApply(xml, text_field, XML::xmlValue, ...)
         txt <- paste0(txt, collapse='')
         return(data.frame(text = txt, stringsAsFactors = FALSE))
     }
     else {
         docs <- XML::xmlToDataFrame(path, stringsAsFactors = FALSE, ...)
-        if (is.numeric(textfield) & (textfield > ncol(docs))) {
-            stop(paste0("There is no ", textfield, "th field in file ", path))
+        if (is.numeric(text_field) & (text_field > ncol(docs))) {
+            stop(paste0("There is no ", text_field, "th field in file ", path))
         }
-        if (is.character(textfield)) {
-            textfieldi <- which(names(docs)==textfield)
-            if (length(textfieldi)==0)
-                stop(paste("There is no node called", textfield, "in file", path))
-            textfield <- textfieldi
+        if (is.character(text_field)) {
+            text_fieldi <- which(names(docs)==text_field)
+            if (length(text_fieldi)==0)
+                stop(paste("There is no node called", text_field, "in file", path))
+            text_field <- text_fieldi
         }
         else {
             if (options('readtext_verbosity')[[1]] >= 1) {
-                warning(paste("You should specify textfield by name rather than by index, unless",
+                warning(paste("You should specify text_field by name rather than by index, unless",
                           "you're certain that your XML file's fields are always in the same order."))
             }
         }
         
         # Because XML::xmlToDataFrame doesn't impute column types, we have to do it
         # ourselves, to match get_csv's behaviour
-        return(data.frame(text = docs[, textfield], 
-                   imputeDocvarsTypes(docs[, -textfield, drop = FALSE]),
+        return(data.frame(text = docs[, text_field], 
+                   imputeDocvarsTypes(docs[, -text_field, drop = FALSE]),
                    stringsAsFactors = FALSE))
     }
 }

--- a/R/readtext.R
+++ b/R/readtext.R
@@ -172,6 +172,15 @@ readtext <- function(file, ignore_missing_files = FALSE, text_field = NULL,
                     verbosity = getOption("readtext_verbosity"),
                     ...) {
     
+    # trap "textfield", issue a warning, and call with text_field
+    thecall <- as.list(match.call())
+    thecall <- thecall[2:length(thecall)]
+    if ("textfield" %in% names(thecall)) {
+        warning("textfield is deprecated; use text_field instead")
+        names(thecall)[which(names(thecall)=="textfield")] <- "text_field"
+        return(do.call(readtext, thecall))
+    }
+    
     # in case the function was called without attaching the package, 
     # in which case the option is never set
     if (is.null(verbosity)) 

--- a/R/readtext.R
+++ b/R/readtext.R
@@ -30,7 +30,7 @@ CHARACTER_CLASS_REPLACEMENTS = list(
 #'   \item{\code{txt}}{plain text files:
 #'   So-called structured text files, which describe both texts and metadata:
 #'   For all structured text filetypes, the column, field, or node 
-#'   which contains the the text must be specified with the \code{textfield}
+#'   which contains the the text must be specified with the \code{text_field}
 #'   parameter, and all other fields are treated as docvars.}
 #'   \item{\code{json}}{data in some form of JavaScript 
 #'   Object Notation, consisting of the texts and optionally additional docvars.
@@ -67,7 +67,7 @@ CHARACTER_CLASS_REPLACEMENTS = list(
 #'   filetypes, so you could have, for example, a remote URL to a zip file which
 #'   contained Twitter JSON files.}
 #'   }
-#' @param textfield a variable (column) name or column number indicating where 
+#' @param text_field a variable (column) name or column number indicating where 
 #'   to find the texts that form the documents for the corpus.  This must be 
 #'   specified for file types \code{.csv} and \code{.json}. For XML files
 #'   an XPath expression can be specified. 
@@ -132,10 +132,10 @@ CHARACTER_CLASS_REPLACEMENTS = list(
 #' str(rt4)
 #' 
 #' ## read in tab-separated data
-#' (rt5 <- readtext(paste0(DATA_DIR, "tsv/dailsample.tsv"), textfield = "speech"))
+#' (rt5 <- readtext(paste0(DATA_DIR, "tsv/dailsample.tsv"), text_field = "speech"))
 #' 
 #' ## read in JSON data
-#' (rt6 <- readtext(paste0(DATA_DIR, "json/inaugural_sample.json"), textfield = "texts"))
+#' (rt6 <- readtext(paste0(DATA_DIR, "json/inaugural_sample.json"), text_field = "texts"))
 #' 
 #' ## read in pdf data
 #' # UNHDR
@@ -166,7 +166,7 @@ CHARACTER_CLASS_REPLACEMENTS = list(
 #' rt10
 #' head(rt10[, -1])
 #' }
-readtext <- function(file, ignore_missing_files = FALSE, textfield = NULL, 
+readtext <- function(file, ignore_missing_files = FALSE, text_field = NULL, 
                     docvarsfrom = c("metadata", "filenames", "filepaths"), dvsep="_", 
                     docvarnames = NULL, encoding = NULL, 
                     verbosity = getOption("readtext_verbosity"),
@@ -190,7 +190,7 @@ readtext <- function(file, ignore_missing_files = FALSE, textfield = NULL,
     # if (!all(docvarsfrom %in% c( c("metadata", "filenames"))))
     #     stop("illegal docvarsfrom value")
      
-    if (is.null(textfield)) textfield <- 1
+    if (is.null(text_field)) text_field <- 1
     files <- listMatchingFiles(file, ignoreMissing = ignore_missing_files)
     
     if (is.null(encoding)) {
@@ -200,11 +200,11 @@ readtext <- function(file, ignore_missing_files = FALSE, textfield = NULL,
         if (length(encoding) != length(files)) {
             stop('encoding parameter must be length 1, or as long as the number of files')
         }
-        sources <- mapply(function(x, e) getSource(f = x, textfield = textfield, encoding = e, ...),
+        sources <- mapply(function(x, e) getSource(f = x, text_field = text_field, encoding = e, ...),
                          files, encoding,
                          SIMPLIFY = FALSE)
     } else {
-        sources <- lapply(files, function(x) getSource(x, textfield = textfield, encoding = encoding, ...))
+        sources <- lapply(files, function(x) getSource(x, text_field = text_field, encoding = encoding, ...))
     }
 
     
@@ -237,7 +237,7 @@ readtext <- function(file, ignore_missing_files = FALSE, textfield = NULL,
 
 ## read each file as appropriate, calling the get_* functions for recognized
 ## file types
-getSource <- function(f, textfield, replace_special_characters = FALSE, ...) {
+getSource <- function(f, text_field, replace_special_characters = FALSE, ...) {
 
     fileType <- tolower(file_ext(f))
     if (fileType %in% SUPPORTED_FILETYPE_MAPPING) {
@@ -256,12 +256,12 @@ getSource <- function(f, textfield, replace_special_characters = FALSE, ...) {
     
     newSource <- switch(fileType, 
                txt = get_txt(f, ...),
-               csv = get_csv(f, textfield, sep=',', ...),
-               tsv = get_csv(f, textfield, sep='\t', ...),
-               tab = get_csv(f, textfield, sep='\t', ...),
-               json = get_json(f, textfield, ...),
-               xml = get_xml(f, textfield, ...),
-               html = get_html(f, textfield=textfield, ...),
+               csv = get_csv(f, text_field, sep=',', ...),
+               tsv = get_csv(f, text_field, sep='\t', ...),
+               tab = get_csv(f, text_field, sep='\t', ...),
+               json = get_json(f, text_field, ...),
+               xml = get_xml(f, text_field, ...),
+               html = get_html(f, text_field=text_field, ...),
                pdf = get_pdf(f, ...),
                docx = get_docx(f, ...),
                doc = get_doc(f, ...)

--- a/inst/doc/readtext_vignette.R
+++ b/inst/doc/readtext_vignette.R
@@ -28,15 +28,15 @@ readtext(paste0(DATA_DIR, "txt/movie_reviews/*"))
 
 ## ------------------------------------------------------------------------
 # Read in comma-separated values
-readtext(paste0(DATA_DIR, "csv/inaugCorpus.csv"), textfield = "texts")
+readtext(paste0(DATA_DIR, "csv/inaugCorpus.csv"), text_field = "texts")
 
 ## ------------------------------------------------------------------------
 # Read in tab-separated values
-readtext(paste0(DATA_DIR, "tsv/dailsample.tsv"), textfield = "speech")
+readtext(paste0(DATA_DIR, "tsv/dailsample.tsv"), text_field = "speech")
 
 ## ------------------------------------------------------------------------
 ## Read in JSON data
-readtext(paste0(DATA_DIR, "json/inaugural_sample.json"), textfield = "texts")
+readtext(paste0(DATA_DIR, "json/inaugural_sample.json"), text_field = "texts")
 
 ## ------------------------------------------------------------------------
 ## Read in Universal Declaration of Human Rights pdf files
@@ -61,7 +61,7 @@ require(quanteda)
 
 ## ------------------------------------------------------------------------
 # read in comma-separated values with readtext
-rt_csv <- readtext(paste0(DATA_DIR, "csv/inaugCorpus.csv"), textfield = "texts")
+rt_csv <- readtext(paste0(DATA_DIR, "csv/inaugCorpus.csv"), text_field = "texts")
 
 # create quanteda corpus
 corpus_csv <- corpus(rt_csv)

--- a/inst/doc/readtext_vignette.Rmd
+++ b/inst/doc/readtext_vignette.Rmd
@@ -68,27 +68,27 @@ readtext(paste0(DATA_DIR, "txt/movie_reviews/*"))
 
 ## 2.2 Comma- or tab-separated values (.csv, .tab, .tsv)
 
-Read in comma separted values (.csv files) that contain textual data. We determine the `texts` variable in our .csv file as the `textfield`. This is the column that contains the actual text. The other columns of the original csv file (`Year`, `President`, `FirstName`) are by default treated as document-level variables. 
+Read in comma separted values (.csv files) that contain textual data. We determine the `texts` variable in our .csv file as the `text_field`. This is the column that contains the actual text. The other columns of the original csv file (`Year`, `President`, `FirstName`) are by default treated as document-level variables. 
 
 ```{r}
 # Read in comma-separated values
-readtext(paste0(DATA_DIR, "csv/inaugCorpus.csv"), textfield = "texts")
+readtext(paste0(DATA_DIR, "csv/inaugCorpus.csv"), text_field = "texts")
 ```
 
 The same procedure applies to tab-separated values.
 
 ```{r}
 # Read in tab-separated values
-readtext(paste0(DATA_DIR, "tsv/dailsample.tsv"), textfield = "speech")
+readtext(paste0(DATA_DIR, "tsv/dailsample.tsv"), text_field = "speech")
 ```
 
 ## 2.3 JSON data (.json)
 
-You can also read .json data. Again you need to specify the `textfield`. 
+You can also read .json data. Again you need to specify the `text_field`. 
 
 ```{r}
 ## Read in JSON data
-readtext(paste0(DATA_DIR, "json/inaugural_sample.json"), textfield = "texts")
+readtext(paste0(DATA_DIR, "json/inaugural_sample.json"), text_field = "texts")
 ```
 
 ## 2.4 PDF files
@@ -144,7 +144,7 @@ You can easily contruct a corpus from a **readtext** object.
 
 ```{r}
 # read in comma-separated values with readtext
-rt_csv <- readtext(paste0(DATA_DIR, "csv/inaugCorpus.csv"), textfield = "texts")
+rt_csv <- readtext(paste0(DATA_DIR, "csv/inaugCorpus.csv"), text_field = "texts")
 
 # create quanteda corpus
 corpus_csv <- corpus(rt_csv)

--- a/inst/doc/readtext_vignette.html
+++ b/inst/doc/readtext_vignette.html
@@ -107,6 +107,20 @@ DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span
 <p>The folder “txt” contains a subfolder named UDHR with .txt files of the Universal Declaration of Human Rights in 13 languages.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Read in all files from a folder</span>
 <span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;txt/UDHR/*&quot;</span>))
+## possible glob pattern
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
 ## readtext object consisting of 13 documents and 0 docvars.
 ## # data.frame [13 × 2]
 ##              doc_id                      text
@@ -125,6 +139,24 @@ DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span
          <span class="dt">docvarnames =</span> <span class="kw">c</span>(<span class="st">&quot;unit&quot;</span>, <span class="st">&quot;context&quot;</span>, <span class="st">&quot;year&quot;</span>, <span class="st">&quot;language&quot;</span>, <span class="st">&quot;party&quot;</span>),
          <span class="dt">dvsep =</span> <span class="st">&quot;_&quot;</span>, 
          <span class="dt">encoding =</span> <span class="st">&quot;ISO-8859-1&quot;</span>)
+## possible glob pattern
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
 ## readtext object consisting of 17 documents and 5 docvars.
 ## # data.frame [17 × 7]
 ##                    doc_id             text  unit context  year language
@@ -139,6 +171,109 @@ DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span
 <p><strong>readtext</strong> can also curse through subdirectories. In our example, the folder <code>txt/movie_reviews</code> contains two subfolders (called <code>neg</code> and <code>pos</code>). We can load all texts included in both folders.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Recurse through subdirectories</span>
 <span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;txt/movie_reviews/*&quot;</span>))
+## possible glob pattern
+## possible glob pattern
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## possible glob pattern
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
 ## readtext object consisting of 100 documents and 0 docvars.
 ## # data.frame [100 × 2]
 ##                    doc_id            text
@@ -156,6 +291,8 @@ DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span
 <p>Read in comma separted values (.csv files) that contain textual data. We determine the <code>texts</code> variable in our .csv file as the <code>textfield</code>. This is the column that contains the actual text. The other columns of the original csv file (<code>Year</code>, <code>President</code>, <code>FirstName</code>) are by default treated as document-level variables.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Read in comma-separated values</span>
 <span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;csv/inaugCorpus.csv&quot;</span>), <span class="dt">textfield =</span> <span class="st">&quot;texts&quot;</span>)
+## possible glob pattern
+## regular file
 ## readtext object consisting of 5 documents and 3 docvars.
 ## # data.frame [5 × 5]
 ##              doc_id            text  Year  President FirstName
@@ -168,6 +305,8 @@ DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span
 <p>The same procedure applies to tab-separated values.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Read in tab-separated values</span>
 <span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;tsv/dailsample.tsv&quot;</span>), <span class="dt">textfield =</span> <span class="st">&quot;speech&quot;</span>)
+## possible glob pattern
+## regular file
 ## readtext object consisting of 33 documents and 9 docvars.
 ## # data.frame [33 × 11]
 ##             doc_id            text speechID memberID partyID constID
@@ -186,6 +325,8 @@ DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span
 <p>You can also read .json data. Again you need to specify the <code>textfield</code>.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">## Read in JSON data
 <span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;json/inaugural_sample.json&quot;</span>), <span class="dt">textfield =</span> <span class="st">&quot;texts&quot;</span>)
+## possible glob pattern
+## regular file
 ## Warning in doTryCatch(return(expr), name, parentenv, handler): Doesn't look
 ## like Tweets json file, trying general JSON
 ## readtext object consisting of 3 documents and 3 docvars.
@@ -205,6 +346,18 @@ DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span
                     <span class="dt">docvarsfrom =</span> <span class="st">&quot;filenames&quot;</span>, 
                     <span class="dt">docvarnames =</span> <span class="kw">c</span>(<span class="st">&quot;document&quot;</span>, <span class="st">&quot;language&quot;</span>),
                     <span class="dt">sep =</span> <span class="st">&quot;_&quot;</span>))
+## possible glob pattern
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
 ## readtext object consisting of 11 documents and 2 docvars.
 ## # data.frame [11 × 4]
 ##             doc_id                      text document language
@@ -222,6 +375,9 @@ DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span
 <p>Microsoft Word formatted files are converted through the package <strong>antiword</strong> for older <code>.doc</code> files, and using <strong>XML</strong> for newer <code>.docx</code> files.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">## Read in Word data (.docx)
 <span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;word/*.docx&quot;</span>))
+## possible glob pattern
+## regular file
+## regular file
 ## readtext object consisting of 2 documents and 0 docvars.
 ## # data.frame [2 × 2]
 ##                        doc_id            text
@@ -248,6 +404,8 @@ DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span
 <p>You can easily contruct a corpus from a <strong>readtext</strong> object.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># read in comma-separated values with readtext</span>
 rt_csv &lt;-<span class="st"> </span><span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;csv/inaugCorpus.csv&quot;</span>), <span class="dt">textfield =</span> <span class="st">&quot;texts&quot;</span>)
+## possible glob pattern
+## regular file
 
 <span class="co"># create quanteda corpus</span>
 corpus_csv &lt;-<span class="st"> </span><span class="kw">corpus</span>(rt_csv)
@@ -262,7 +420,7 @@ corpus_csv &lt;-<span class="st"> </span><span class="kw">corpus</span>(rt_csv)
 ##  inaugCorpus.csv.5   804   2381        45 1805  Jefferson    Thomas
 ## 
 ## Source:  /Users/kbenoit/Dropbox (Personal)/GitHub/readtext/vignettes/* on x86_64 by kbenoit
-## Created: Fri Apr 28 07:13:04 2017
+## Created: Mon May 15 09:56:04 2017
 ## Notes:</code></pre></div>
 </div>
 <div id="solving-common-problems" class="section level1">
@@ -349,6 +507,44 @@ fileencodings[notAvailableIndex]
                  <span class="dt">encoding =</span> fileencodings,
                  <span class="dt">docvarsfrom =</span> <span class="st">&quot;filenames&quot;</span>, 
                  <span class="dt">docvarnames =</span> <span class="kw">c</span>(<span class="st">&quot;document&quot;</span>, <span class="st">&quot;language&quot;</span>, <span class="st">&quot;input_encoding&quot;</span>))
+## archive
+## possible glob pattern
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
+## regular file
 <span class="kw">print</span>(txts, <span class="dt">n =</span> <span class="dv">50</span>)
 ## readtext object consisting of 36 documents and 3 docvars.
 ## # data.frame [36 × 5]
@@ -411,7 +607,7 @@ fileencodings[notAvailableIndex]
 ##    Arabic   WINDOWS-1256
 ## 
 ## Source:  /Users/kbenoit/Dropbox (Personal)/GitHub/readtext/vignettes/* on x86_64 by kbenoit
-## Created: Fri Apr 28 07:13:04 2017
+## Created: Mon May 15 09:56:04 2017
 ## Notes:</code></pre></div>
 </div>
 </div>

--- a/inst/doc/readtext_vignette.html
+++ b/inst/doc/readtext_vignette.html
@@ -107,20 +107,6 @@ DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span
 <p>The folder “txt” contains a subfolder named UDHR with .txt files of the Universal Declaration of Human Rights in 13 languages.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Read in all files from a folder</span>
 <span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;txt/UDHR/*&quot;</span>))
-## possible glob pattern
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
 ## readtext object consisting of 13 documents and 0 docvars.
 ## # data.frame [13 × 2]
 ##              doc_id                      text
@@ -139,24 +125,6 @@ DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span
          <span class="dt">docvarnames =</span> <span class="kw">c</span>(<span class="st">&quot;unit&quot;</span>, <span class="st">&quot;context&quot;</span>, <span class="st">&quot;year&quot;</span>, <span class="st">&quot;language&quot;</span>, <span class="st">&quot;party&quot;</span>),
          <span class="dt">dvsep =</span> <span class="st">&quot;_&quot;</span>, 
          <span class="dt">encoding =</span> <span class="st">&quot;ISO-8859-1&quot;</span>)
-## possible glob pattern
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
 ## readtext object consisting of 17 documents and 5 docvars.
 ## # data.frame [17 × 7]
 ##                    doc_id             text  unit context  year language
@@ -171,109 +139,6 @@ DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span
 <p><strong>readtext</strong> can also curse through subdirectories. In our example, the folder <code>txt/movie_reviews</code> contains two subfolders (called <code>neg</code> and <code>pos</code>). We can load all texts included in both folders.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Recurse through subdirectories</span>
 <span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;txt/movie_reviews/*&quot;</span>))
-## possible glob pattern
-## possible glob pattern
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## possible glob pattern
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
 ## readtext object consisting of 100 documents and 0 docvars.
 ## # data.frame [100 × 2]
 ##                    doc_id            text
@@ -288,11 +153,9 @@ DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span
 </div>
 <div id="comma--or-tab-separated-values-.csv-.tab-.tsv" class="section level2">
 <h2>2.2 Comma- or tab-separated values (.csv, .tab, .tsv)</h2>
-<p>Read in comma separted values (.csv files) that contain textual data. We determine the <code>texts</code> variable in our .csv file as the <code>textfield</code>. This is the column that contains the actual text. The other columns of the original csv file (<code>Year</code>, <code>President</code>, <code>FirstName</code>) are by default treated as document-level variables.</p>
+<p>Read in comma separted values (.csv files) that contain textual data. We determine the <code>texts</code> variable in our .csv file as the <code>text_field</code>. This is the column that contains the actual text. The other columns of the original csv file (<code>Year</code>, <code>President</code>, <code>FirstName</code>) are by default treated as document-level variables.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Read in comma-separated values</span>
-<span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;csv/inaugCorpus.csv&quot;</span>), <span class="dt">textfield =</span> <span class="st">&quot;texts&quot;</span>)
-## possible glob pattern
-## regular file
+<span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;csv/inaugCorpus.csv&quot;</span>), <span class="dt">text_field =</span> <span class="st">&quot;texts&quot;</span>)
 ## readtext object consisting of 5 documents and 3 docvars.
 ## # data.frame [5 × 5]
 ##              doc_id            text  Year  President FirstName
@@ -304,9 +167,7 @@ DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span
 ## 5 inaugCorpus.csv.5 &quot;Proceeding&quot;...  1805  Jefferson    Thomas</code></pre></div>
 <p>The same procedure applies to tab-separated values.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Read in tab-separated values</span>
-<span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;tsv/dailsample.tsv&quot;</span>), <span class="dt">textfield =</span> <span class="st">&quot;speech&quot;</span>)
-## possible glob pattern
-## regular file
+<span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;tsv/dailsample.tsv&quot;</span>), <span class="dt">text_field =</span> <span class="st">&quot;speech&quot;</span>)
 ## readtext object consisting of 33 documents and 9 docvars.
 ## # data.frame [33 × 11]
 ##             doc_id            text speechID memberID partyID constID
@@ -322,11 +183,9 @@ DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span
 </div>
 <div id="json-data-.json" class="section level2">
 <h2>2.3 JSON data (.json)</h2>
-<p>You can also read .json data. Again you need to specify the <code>textfield</code>.</p>
+<p>You can also read .json data. Again you need to specify the <code>text_field</code>.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">## Read in JSON data
-<span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;json/inaugural_sample.json&quot;</span>), <span class="dt">textfield =</span> <span class="st">&quot;texts&quot;</span>)
-## possible glob pattern
-## regular file
+<span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;json/inaugural_sample.json&quot;</span>), <span class="dt">text_field =</span> <span class="st">&quot;texts&quot;</span>)
 ## Warning in doTryCatch(return(expr), name, parentenv, handler): Doesn't look
 ## like Tweets json file, trying general JSON
 ## readtext object consisting of 3 documents and 3 docvars.
@@ -346,18 +205,6 @@ DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span
                     <span class="dt">docvarsfrom =</span> <span class="st">&quot;filenames&quot;</span>, 
                     <span class="dt">docvarnames =</span> <span class="kw">c</span>(<span class="st">&quot;document&quot;</span>, <span class="st">&quot;language&quot;</span>),
                     <span class="dt">sep =</span> <span class="st">&quot;_&quot;</span>))
-## possible glob pattern
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
 ## readtext object consisting of 11 documents and 2 docvars.
 ## # data.frame [11 × 4]
 ##             doc_id                      text document language
@@ -375,9 +222,6 @@ DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span
 <p>Microsoft Word formatted files are converted through the package <strong>antiword</strong> for older <code>.doc</code> files, and using <strong>XML</strong> for newer <code>.docx</code> files.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">## Read in Word data (.docx)
 <span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;word/*.docx&quot;</span>))
-## possible glob pattern
-## regular file
-## regular file
 ## readtext object consisting of 2 documents and 0 docvars.
 ## # data.frame [2 × 2]
 ##                        doc_id            text
@@ -403,9 +247,7 @@ DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">require</span>(quanteda)</code></pre></div>
 <p>You can easily contruct a corpus from a <strong>readtext</strong> object.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># read in comma-separated values with readtext</span>
-rt_csv &lt;-<span class="st"> </span><span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;csv/inaugCorpus.csv&quot;</span>), <span class="dt">textfield =</span> <span class="st">&quot;texts&quot;</span>)
-## possible glob pattern
-## regular file
+rt_csv &lt;-<span class="st"> </span><span class="kw">readtext</span>(<span class="kw">paste0</span>(DATA_DIR, <span class="st">&quot;csv/inaugCorpus.csv&quot;</span>), <span class="dt">text_field =</span> <span class="st">&quot;texts&quot;</span>)
 
 <span class="co"># create quanteda corpus</span>
 corpus_csv &lt;-<span class="st"> </span><span class="kw">corpus</span>(rt_csv)
@@ -420,7 +262,7 @@ corpus_csv &lt;-<span class="st"> </span><span class="kw">corpus</span>(rt_csv)
 ##  inaugCorpus.csv.5   804   2381        45 1805  Jefferson    Thomas
 ## 
 ## Source:  /Users/kbenoit/Dropbox (Personal)/GitHub/readtext/vignettes/* on x86_64 by kbenoit
-## Created: Mon May 15 09:56:04 2017
+## Created: Mon May 15 10:06:58 2017
 ## Notes:</code></pre></div>
 </div>
 <div id="solving-common-problems" class="section level1">
@@ -507,44 +349,6 @@ fileencodings[notAvailableIndex]
                  <span class="dt">encoding =</span> fileencodings,
                  <span class="dt">docvarsfrom =</span> <span class="st">&quot;filenames&quot;</span>, 
                  <span class="dt">docvarnames =</span> <span class="kw">c</span>(<span class="st">&quot;document&quot;</span>, <span class="st">&quot;language&quot;</span>, <span class="st">&quot;input_encoding&quot;</span>))
-## archive
-## possible glob pattern
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
-## regular file
 <span class="kw">print</span>(txts, <span class="dt">n =</span> <span class="dv">50</span>)
 ## readtext object consisting of 36 documents and 3 docvars.
 ## # data.frame [36 × 5]
@@ -607,7 +411,7 @@ fileencodings[notAvailableIndex]
 ##    Arabic   WINDOWS-1256
 ## 
 ## Source:  /Users/kbenoit/Dropbox (Personal)/GitHub/readtext/vignettes/* on x86_64 by kbenoit
-## Created: Mon May 15 09:56:04 2017
+## Created: Mon May 15 10:06:58 2017
 ## Notes:</code></pre></div>
 </div>
 </div>

--- a/man/readtext.Rd
+++ b/man/readtext.Rd
@@ -4,7 +4,7 @@
 \alias{readtext}
 \title{read a text file(s)}
 \usage{
-readtext(file, ignore_missing_files = FALSE, textfield = NULL,
+readtext(file, ignore_missing_files = FALSE, text_field = NULL,
   docvarsfrom = c("metadata", "filenames", "filepaths"), dvsep = "_",
   docvarnames = NULL, encoding = NULL,
   verbosity = getOption("readtext_verbosity"), ...)
@@ -20,7 +20,7 @@ automagically handle a number of common scenarios, so the value can be a
 \item{\code{txt}}{plain text files:
 So-called structured text files, which describe both texts and metadata:
 For all structured text filetypes, the column, field, or node 
-which contains the the text must be specified with the \code{textfield}
+which contains the the text must be specified with the \code{text_field}
 parameter, and all other fields are treated as docvars.}
 \item{\code{json}}{data in some form of JavaScript 
 Object Notation, consisting of the texts and optionally additional docvars.
@@ -64,7 +64,7 @@ Note that this can happen in a number of ways, including passing a path
 to a file that does not exist, to an empty archive file, or to a glob 
 pattern that matches no files.}
 
-\item{textfield}{a variable (column) name or column number indicating where 
+\item{text_field}{a variable (column) name or column number indicating where 
 to find the texts that form the documents for the corpus.  This must be 
 specified for file types \code{.csv} and \code{.json}. For XML files
 an XPath expression can be specified.}
@@ -136,10 +136,10 @@ rt4 <- readtext(paste0(DATA_DIR, "csv/inaugCorpus.csv"))
 str(rt4)
 
 ## read in tab-separated data
-(rt5 <- readtext(paste0(DATA_DIR, "tsv/dailsample.tsv"), textfield = "speech"))
+(rt5 <- readtext(paste0(DATA_DIR, "tsv/dailsample.tsv"), text_field = "speech"))
 
 ## read in JSON data
-(rt6 <- readtext(paste0(DATA_DIR, "json/inaugural_sample.json"), textfield = "texts"))
+(rt6 <- readtext(paste0(DATA_DIR, "json/inaugural_sample.json"), text_field = "texts"))
 
 ## read in pdf data
 # UNHDR

--- a/tests/testthat/test-readtext-methods.R
+++ b/tests/testthat/test-readtext-methods.R
@@ -19,14 +19,14 @@ test_that("test print.readtext", {
     )
     
     expect_that(
-        print(readtext('../data/csv/test.csv', textfield='text')),
+        print(readtext('../data/csv/test.csv', text_field='text')),
         prints_text('readtext object consisting of 2 documents and 2 docvars.')
     )
 })
 
 
 test_that("test as.character.readtext", {
-    tmp <- readtext('../data/csv/test.csv', textfield='text')
+    tmp <- readtext('../data/csv/test.csv', text_field='text')
     expect_equal(
         as.character(tmp),
         c(test.csv.1 = "Lorem ipsum.", test.csv.2 = "Dolor sit")

--- a/tests/testthat/test-readtext-uppercaseextensions.R
+++ b/tests/testthat/test-readtext-uppercaseextensions.R
@@ -16,7 +16,7 @@ test_that("test case for txt files with glob", {
 test_that("test case for csv files with glob", {
     expect_equal(
         length(texts(readtext(
-            '../data/CSVcaps/*.CSV', textfield='text'
+            '../data/CSVcaps/*.CSV', text_field='text'
         ))),
         4
     )

--- a/tests/testthat/test-readtext.R
+++ b/tests/testthat/test-readtext.R
@@ -862,3 +862,28 @@ test_that("messages from listMatchingFile",{
         shows_message('archive')
     )
 })
+
+test_that("readtext called with textfield works with deprecation warning", {
+    expect_equal(
+        length(texts(readtext(
+            '../data/csv/*.csv', textfield='text'
+        ))),
+        4
+    )
+    expect_equal(
+        nrow(docvars(readtext(
+            '../data/csv/*.csv', textfield='text'
+        ))),
+        4
+    )
+    expect_equal(
+        length(texts(readtext(
+            '../data/csv/*.csv', textfield='text'
+        ))),
+        4
+    )
+    expect_warning(
+        readtext('../data/csv/*.csv', textfield='text'),
+        "textfield is deprecated; use text_field instead"
+    )
+})

--- a/tests/testthat/test-readtext.R
+++ b/tests/testthat/test-readtext.R
@@ -1,6 +1,6 @@
 # TODO: re-do docs
 # TODO: Check and remove extranous codes # TODO: recurse file listing for e.g. remote ZIP file
-# TODO: readtext with csv doesn't seem to require textfield
+# TODO: readtext with csv doesn't seem to require text_field
 
 
 context('test readtext.R')
@@ -67,13 +67,13 @@ test_that("test readtext with glob-style mask", {
 test_that("test structured readtext with glob-style mask", {
     expect_equal(
         length(texts(readtext(
-            '../data/csv/*.csv', textfield='text'
+            '../data/csv/*.csv', text_field='text'
         ))),
         4
     )
     expect_equal(
         nrow(docvars(readtext(
-            '../data/csv/*.csv', textfield='text'
+            '../data/csv/*.csv', text_field='text'
         ))),
         4
     )
@@ -96,7 +96,7 @@ test_that("test remote text file", {
 
 test_that("test remote csv file", {
     expect_equal(
-        texts(readtext("https://raw.githubusercontent.com/kbenoit/readtext/master/tests/data/csv/test.csv", textfield='text')),
+        texts(readtext("https://raw.githubusercontent.com/kbenoit/readtext/master/tests/data/csv/test.csv", text_field='text')),
         c(test.csv.1 = 'Lorem ipsum.', test.csv.2 = 'Dolor sit')
     )
 })
@@ -144,7 +144,7 @@ test_that("test warning for unrecognized filetype", {
 # TODO: Refactor this to loop over filetypes
 test_that("test csv files", {
     # Test corpus object
-    testcorpus <- readtext('../data/csv/test.csv', textfield='text')
+    testcorpus <- readtext('../data/csv/test.csv', text_field='text')
     expect_that(
         docvars(testcorpus),
         equals(data.frame(list(colour = c('green', 'red'), number = c(42, 99)), 
@@ -157,19 +157,19 @@ test_that("test csv files", {
     )
     
     expect_that(
-        docvars(readtext('../data/csv/*', textfield='nonesuch')),
+        docvars(readtext('../data/csv/*', text_field='nonesuch')),
         throws_error("There is no field called")
     )
     
     expect_that(
-        docvars(readtext('../data/csv/*', textfield = 9000)),
+        docvars(readtext('../data/csv/*', text_field = 9000)),
         throws_error("There is no 9000th field")
     )
     
 })
 
 test_that("test tab files", {
-    testreadtext <- readtext('../data/tab/test.tab', textfield = 'text')
+    testreadtext <- readtext('../data/tab/test.tab', text_field = 'text')
     expect_that(
         docvars(testreadtext),
         equals(data.frame(list(colour=c('green', 'red'), number=c(42, 99)), 
@@ -182,14 +182,14 @@ test_that("test tab files", {
     )
     
     expect_that(
-        readtext('../data/tab/test.tab', textfield='nonexistant'),
+        readtext('../data/tab/test.tab', text_field='nonexistant'),
         throws_error('There is no field called nonexistant')
     )
     
 })
 
 test_that("test tsv files", {
-    testreadtext <- readtext('../data/tsv/test.tsv', textfield='text')
+    testreadtext <- readtext('../data/tsv/test.tsv', text_field='text')
     expect_that(
         docvars(testreadtext),
         equals(data.frame(list(colour=c('green', 'red'), number=c(42, 99)), 
@@ -202,7 +202,7 @@ test_that("test tsv files", {
     )
     
     expect_that(
-        readtext('../data/tsv/test.tsv', textfield='nonexistant'),
+        readtext('../data/tsv/test.tsv', text_field='nonexistant'),
         throws_error('There is no field called nonexistant')
     )
     
@@ -211,7 +211,7 @@ test_that("test tsv files", {
 
 test_that("test xml files", {
     # Test corpus object
-    testcorpus <- readtext('../data/xml/test.xml', textfield='text')
+    testcorpus <- readtext('../data/xml/test.xml', text_field='text')
     expect_that(
         data.frame(testcorpus[,-1]),
         equals(data.frame(list(colour=c('green', 'red'), number=c(42, 99)), 
@@ -229,11 +229,11 @@ test_that("test xml files", {
 
     
     expect_that(
-        readtext('../data/xml/test.xml', textfield=1),
-        gives_warning('You should specify textfield by name.*')
+        readtext('../data/xml/test.xml', text_field=1),
+        gives_warning('You should specify text_field by name.*')
     )
     expect_that(
-        unname(texts(readtext('../data/xml/test.xml', textfield=1))),
+        unname(texts(readtext('../data/xml/test.xml', text_field=1))),
         equals(c('Lorem ipsum.', 'Dolor sit'))
     )
     expect_that(
@@ -243,11 +243,11 @@ test_that("test xml files", {
 
     
     expect_that(
-        docvars(readtext('../data/xml/*', textfield='nonesuch')),
+        docvars(readtext('../data/xml/*', text_field='nonesuch')),
         throws_error("There is no node called")
     )
     expect_that(
-        docvars(readtext('../data/xml/*', textfield=9000)),
+        docvars(readtext('../data/xml/*', text_field=9000)),
         throws_error("There is no 9000th field")
     )
 })
@@ -259,7 +259,7 @@ test_that("test xml files with XPath", {
     names(expected) <- 'tei.xml'
 
     actual <- readtext('../data/xml/tei.xml',
-                      textfield='/tei:TEI/tei:text/tei:body//tei:p',
+                      text_field='/tei:TEI/tei:text/tei:body//tei:p',
                       namespaces=c(tei = "http://www.tei-c.org/ns/1.0"))
 
     expect_equal(texts(actual), expected)
@@ -292,7 +292,7 @@ test_that("test readtext() with docvarsfrom=filenames", {
     )
     
     expect_that(
-        docvars(readtext('../data/docvars/two/*json', textfield='nonesuch', 
+        docvars(readtext('../data/docvars/two/*json', text_field='nonesuch', 
                         docvarsfrom='filenames')),
         throws_error("There is no field called")
     )
@@ -342,7 +342,7 @@ test_that("test readtext() with docvarsfrom=filenames", {
     
     #  Docvars from both metadata and filename
     expect_equal(
-        docvars(readtext('../data/docvars/csv/*', docvarsfrom=c('filenames'), docvarnames=c('id', 'fruit'), textfield='text')),
+        docvars(readtext('../data/docvars/csv/*', docvarsfrom=c('filenames'), docvarnames=c('id', 'fruit'), text_field='text')),
         data.frame(list(shape=c('round', NA), texture=c(NA, 'rough'), id=c(1, 2), fruit=c('apple', 'orange')), 
                    stringsAsFactors = FALSE,
                    row.names = c("1_apple.csv", "2_orange.csv"))
@@ -350,7 +350,7 @@ test_that("test readtext() with docvarsfrom=filenames", {
     
     # #  Docvars from both metadata and filename
     # expect_equal(
-    #     docvars(readtext('../data/docvars/json/*', docvarsfrom=c('filenames', 'metadata'), docvarnames=c('id', 'fruit'), textfield='text')),
+    #     docvars(readtext('../data/docvars/json/*', docvarsfrom=c('filenames', 'metadata'), docvarnames=c('id', 'fruit'), text_field='text')),
     #     data.frame(list(id=c(1, 2), fruit=c('apple', 'orange'), shape=c('round', NA), texture=c(NA, 'rough')), stringsAsFactors=FALSE)
     # )
     
@@ -418,7 +418,7 @@ test_that("An empty tar.gz file raises an error",{
 test_that("test reading structured text files with different columns", {
     testcorpus <- readtext(
         "../data/fruits/*.csv",
-        textfield='text'
+        text_field='text'
     )
     
     expect_that(
@@ -550,7 +550,7 @@ test_that("text vectors have names of the files they come from by default (bug 2
         )
 
         actual_names <- names(texts(readtext(
-            '../data/csv/*.csv', textfield='text'
+            '../data/csv/*.csv', text_field='text'
         )))
         expect_equal(
             setdiff(
@@ -659,7 +659,7 @@ test_that("test json files", {
     skip_on_cran()
     skip_on_travis()
     expect_equal(
-        unname(texts(readtext('../data/json/*json', textfield='text'))),
+        unname(texts(readtext('../data/json/*json', text_field='text'))),
         c("Lorem ipsum", "Dolor sit", "The quick", "brown fox", "Now is the winter")
     )
     
@@ -671,7 +671,7 @@ test_that("test json files", {
         stringsAsFactors = FALSE)
     expected_docvars <- expected_docvars[order(expected_docvars$number),]
     row.names(expected_docvars) <- NULL
-    actual_docvars <- docvars(readtext('../data/json/*json', textfield='text'))
+    actual_docvars <- docvars(readtext('../data/json/*json', text_field='text'))
     actual_docvars <- actual_docvars[order(actual_docvars$number),]
     row.names(actual_docvars) <- NULL
     row.names(actual_docvars)
@@ -682,12 +682,12 @@ test_that("test json files", {
     )
     
     expect_that(
-        texts(readtext('../data/json/*json', textfield=1)),
-        throws_error('Cannot use numeric textfield with json file')
+        texts(readtext('../data/json/*json', text_field=1)),
+        throws_error('Cannot use numeric text_field with json file')
     )
     
     expect_that(
-        texts(readtext('../data/json/test3.json', textfield='nonesuch')),
+        texts(readtext('../data/json/test3.json', text_field='nonesuch')),
         throws_error('There is no field called nonesuch in file')
     )
     

--- a/vignettes/readtext_vignette.Rmd
+++ b/vignettes/readtext_vignette.Rmd
@@ -68,27 +68,27 @@ readtext(paste0(DATA_DIR, "txt/movie_reviews/*"))
 
 ## 2.2 Comma- or tab-separated values (.csv, .tab, .tsv)
 
-Read in comma separted values (.csv files) that contain textual data. We determine the `texts` variable in our .csv file as the `textfield`. This is the column that contains the actual text. The other columns of the original csv file (`Year`, `President`, `FirstName`) are by default treated as document-level variables. 
+Read in comma separted values (.csv files) that contain textual data. We determine the `texts` variable in our .csv file as the `text_field`. This is the column that contains the actual text. The other columns of the original csv file (`Year`, `President`, `FirstName`) are by default treated as document-level variables. 
 
 ```{r}
 # Read in comma-separated values
-readtext(paste0(DATA_DIR, "csv/inaugCorpus.csv"), textfield = "texts")
+readtext(paste0(DATA_DIR, "csv/inaugCorpus.csv"), text_field = "texts")
 ```
 
 The same procedure applies to tab-separated values.
 
 ```{r}
 # Read in tab-separated values
-readtext(paste0(DATA_DIR, "tsv/dailsample.tsv"), textfield = "speech")
+readtext(paste0(DATA_DIR, "tsv/dailsample.tsv"), text_field = "speech")
 ```
 
 ## 2.3 JSON data (.json)
 
-You can also read .json data. Again you need to specify the `textfield`. 
+You can also read .json data. Again you need to specify the `text_field`. 
 
 ```{r}
 ## Read in JSON data
-readtext(paste0(DATA_DIR, "json/inaugural_sample.json"), textfield = "texts")
+readtext(paste0(DATA_DIR, "json/inaugural_sample.json"), text_field = "texts")
 ```
 
 ## 2.4 PDF files
@@ -144,7 +144,7 @@ You can easily contruct a corpus from a **readtext** object.
 
 ```{r}
 # read in comma-separated values with readtext
-rt_csv <- readtext(paste0(DATA_DIR, "csv/inaugCorpus.csv"), textfield = "texts")
+rt_csv <- readtext(paste0(DATA_DIR, "csv/inaugCorpus.csv"), text_field = "texts")
 
 # create quanteda corpus
 corpus_csv <- corpus(rt_csv)


### PR DESCRIPTION
Solves #83 

- changes `readtext()` argument from `textfield` to `text_field`, to make it consistent with **quanteda**'s `corpus()` function.
- changes all associated files, man pages, vignettes, etc
- traps the usage of `textfield` and issues a warning (but still works)
 