### PR TITLE
Dev tif

### DIFF
--- a/R/readtext-methods.R
+++ b/R/readtext-methods.R
@@ -13,10 +13,10 @@
 print.readtext <- function(x, n = 6L, text_width = 10L, ...) {
     cat("readtext object consisting of ", nrow(x), 
         " document", ifelse(nrow(x) == 1, "", "s"), " and ", 
-        ncol(x)-1, " docvar", ifelse((ncol(x)-1) == 1, "", "s"), 
+        ncol(x)-2, " docvar", ifelse((ncol(x)-2) == 1, "", "s"), 
         ".\n", sep="")
     x$text <- paste0("\"", stringi::stri_sub(x$text, length = text_width), "\"...")
-    x <- cbind(data.frame(doc_id = rownames(x), stringsAsFactors = FALSE), x)
+    # x <- cbind(data.frame(doc_id = rownames(x), stringsAsFactors = FALSE), x)
     class(x) <- "data.frame"
     print(tibble::trunc_mat(x, n = n))
 }
@@ -31,7 +31,7 @@ print.readtext <- function(x, n = 6L, text_width = 10L, ...) {
 #' @export
 as.character.readtext <- function(x, ...) {
     result <- x[["text"]]
-    names(result) <- row.names(x)
+    names(result) <- x[["doc_id"]]
     result
 }
 

--- a/R/readtext-package.R
+++ b/R/readtext-package.R
@@ -15,7 +15,7 @@
 #' @section Package options: \describe{ \item{\code{readtext_verbosity}}{Default
 #'   verbosity for messages produced when reading files.  See
 #'   \code{\link{readtext}}.} }
-#' @author Ken Benoit, Paul Nulty, and Adam Obeng
+#' @author Ken Benoit, Adam Obeng, and Paul Nulty
 #' @docType package
 #' @name readtext-package
 NULL

--- a/R/readtext.R
+++ b/R/readtext.R
@@ -218,7 +218,8 @@ readtext <- function(file, ignore_missing_files = FALSE, text_field = NULL,
 
     
     # combine all of the data.frames returned
-    result <- data.frame(data.table::rbindlist(sources, use.names = TRUE, fill = TRUE),
+    result <- data.frame(doc_id = "", 
+                         data.table::rbindlist(sources, use.names = TRUE, fill = TRUE),
                          stringsAsFactors = FALSE)
 
     # this is in case some smart-alec (like AO) globs different directories 
@@ -239,6 +240,10 @@ readtext <- function(file, ignore_missing_files = FALSE, text_field = NULL,
                                                    docvarnames = docvarnames, include_path=TRUE)
         result <- cbind(result, imputeDocvarsTypes(filenameDocvars))
     }
+    
+    # change rownames to doc_id 
+    result$doc_id <- rownames(result)
+    rownames(result) <- NULL
     
     class(result) <- c("readtext", class(result))
     result

--- a/R/readtext.R
+++ b/R/readtext.R
@@ -104,9 +104,11 @@ CHARACTER_CLASS_REPLACEMENTS = list(
 #'   for specifying an input encoding option, which is specified in the same was
 #'   as it would be give to \code{\link{iconv}}.  See the Encoding section of 
 #'   \link{file} for details.  
-#' @return a data.frame consisting of a first column \code{text} that contains
-#' the texts, with any additional columns consisting of document-level variables either found in the 
-#' file containing the texts, or created through the \code{readtext} call.
+#' @return a data.frame consisting of a columns \code{doc_id} and \code{text} 
+#'   that contain a document identifier and the texts respectively, with any 
+#'   additional columns consisting of document-level variables either found 
+#'   in the file containing the texts, or created through the 
+#'   \code{readtext} call.
 #' @export
 #' @importFrom utils unzip type.convert
 #' @importFrom httr GET write_disk

--- a/inst/doc/readtext_vignette.html
+++ b/inst/doc/readtext_vignette.html
@@ -110,7 +110,7 @@ DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span
 ## readtext object consisting of 13 documents and 0 docvars.
 ## # data.frame [13 × 2]
 ##              doc_id                      text
-## *             &lt;chr&gt;                     &lt;chr&gt;
+##               &lt;chr&gt;                     &lt;chr&gt;
 ## 1  UDHR_chinese.txt &quot;世界人权宣言\n联合国&quot;...
 ## 2    UDHR_czech.txt           &quot;VŠEOBECNÁ &quot;...
 ## 3   UDHR_danish.txt           &quot;Den 10. de&quot;...
@@ -128,7 +128,7 @@ DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span
 ## readtext object consisting of 17 documents and 5 docvars.
 ## # data.frame [17 × 7]
 ##                    doc_id             text  unit context  year language
-## *                   &lt;chr&gt;            &lt;chr&gt; &lt;chr&gt;   &lt;chr&gt; &lt;int&gt;    &lt;chr&gt;
+##                     &lt;chr&gt;            &lt;chr&gt; &lt;chr&gt;   &lt;chr&gt; &lt;int&gt;    &lt;chr&gt;
 ## 1 EU_euro_2004_de_PSE.txt  &quot;PES · PSE &quot;...    EU    euro  2004       de
 ## 2   EU_euro_2004_de_V.txt  &quot;Gemeinsame&quot;...    EU    euro  2004       de
 ## 3 EU_euro_2004_en_PSE.txt  &quot;PES · PSE &quot;...    EU    euro  2004       en
@@ -142,7 +142,7 @@ DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span
 ## readtext object consisting of 100 documents and 0 docvars.
 ## # data.frame [100 × 2]
 ##                    doc_id            text
-## *                   &lt;chr&gt;           &lt;chr&gt;
+##                     &lt;chr&gt;           &lt;chr&gt;
 ## 1 neg/neg_cv000_29416.txt &quot;plot : two&quot;...
 ## 2 neg/neg_cv001_19502.txt &quot;the happy &quot;...
 ## 3 neg/neg_cv002_17424.txt &quot;it is movi&quot;...
@@ -159,7 +159,7 @@ DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span
 ## readtext object consisting of 5 documents and 3 docvars.
 ## # data.frame [5 × 5]
 ##              doc_id            text  Year  President FirstName
-## *             &lt;chr&gt;           &lt;chr&gt; &lt;int&gt;      &lt;chr&gt;     &lt;chr&gt;
+##               &lt;chr&gt;           &lt;chr&gt; &lt;int&gt;      &lt;chr&gt;     &lt;chr&gt;
 ## 1 inaugCorpus.csv.1 &quot;Fellow-Cit&quot;...  1789 Washington    George
 ## 2 inaugCorpus.csv.2 &quot;Fellow cit&quot;...  1793 Washington    George
 ## 3 inaugCorpus.csv.3 &quot;When it wa&quot;...  1797      Adams      John
@@ -171,7 +171,7 @@ DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span
 ## readtext object consisting of 33 documents and 9 docvars.
 ## # data.frame [33 × 11]
 ##             doc_id            text speechID memberID partyID constID
-## *            &lt;chr&gt;           &lt;chr&gt;    &lt;int&gt;    &lt;int&gt;   &lt;int&gt;   &lt;int&gt;
+##              &lt;chr&gt;           &lt;chr&gt;    &lt;int&gt;    &lt;int&gt;   &lt;int&gt;   &lt;int&gt;
 ## 1 dailsample.tsv.1 &quot;Molaimse d&quot;...        1      977      22     158
 ## 2 dailsample.tsv.2 &quot;Is bród mó&quot;...        2     1603      22     103
 ## 3 dailsample.tsv.3 &quot;' A cháird&quot;...        3      116      22     178
@@ -191,7 +191,7 @@ DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span
 ## readtext object consisting of 3 documents and 3 docvars.
 ## # data.frame [3 × 5]
 ##                    doc_id            text  Year  President FirstName
-## *                   &lt;chr&gt;           &lt;chr&gt; &lt;int&gt;      &lt;chr&gt;     &lt;chr&gt;
+##                     &lt;chr&gt;           &lt;chr&gt; &lt;int&gt;      &lt;chr&gt;     &lt;chr&gt;
 ## 1 inaugural_sample.json.1 &quot;Fellow-Cit&quot;...  1789 Washington    George
 ## 2 inaugural_sample.json.2 &quot;Fellow cit&quot;...  1793 Washington    George
 ## 3 inaugural_sample.json.3 &quot;When it wa&quot;...  1797      Adams      John</code></pre></div>
@@ -208,7 +208,7 @@ DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span
 ## readtext object consisting of 11 documents and 2 docvars.
 ## # data.frame [11 × 4]
 ##             doc_id                      text document language
-## *            &lt;chr&gt;                     &lt;chr&gt;    &lt;chr&gt;    &lt;chr&gt;
+##              &lt;chr&gt;                     &lt;chr&gt;    &lt;chr&gt;    &lt;chr&gt;
 ## 1 UDHR_chinese.pdf &quot;世界人权宣言\n联合国&quot;...     UDHR  chinese
 ## 2   UDHR_czech.pdf           &quot;VŠEOBECNÁ &quot;...     UDHR    czech
 ## 3  UDHR_danish.pdf           &quot;Den 10. de&quot;...     UDHR   danish
@@ -225,7 +225,7 @@ DATA_DIR &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span
 ## readtext object consisting of 2 documents and 0 docvars.
 ## # data.frame [2 × 2]
 ##                        doc_id            text
-## *                       &lt;chr&gt;           &lt;chr&gt;
+##                         &lt;chr&gt;           &lt;chr&gt;
 ## 1 UK_2015_EccentricParty.docx &quot;The Eccent&quot;...
 ## 2     UK_2015_LoonyParty.docx &quot;The Offici&quot;...</code></pre></div>
 </div>
@@ -254,15 +254,15 @@ corpus_csv &lt;-<span class="st"> </span><span class="kw">corpus</span>(rt_csv)
 <span class="kw">summary</span>(corpus_csv, <span class="dv">5</span>)
 ## Corpus consisting of 5 documents.
 ## 
-##               Text Types Tokens Sentences Year  President FirstName
-##  inaugCorpus.csv.1   626   1542        23 1789 Washington    George
-##  inaugCorpus.csv.2    96    147         4 1793 Washington    George
-##  inaugCorpus.csv.3   826   2584        37 1797      Adams      John
-##  inaugCorpus.csv.4   716   1935        41 1801  Jefferson    Thomas
-##  inaugCorpus.csv.5   804   2381        45 1805  Jefferson    Thomas
+##   Text Types Tokens Sentences            doc_id Year  President FirstName
+##  text1   626   1542        23 inaugCorpus.csv.1 1789 Washington    George
+##  text2    96    147         4 inaugCorpus.csv.2 1793 Washington    George
+##  text3   826   2584        37 inaugCorpus.csv.3 1797      Adams      John
+##  text4   716   1935        41 inaugCorpus.csv.4 1801  Jefferson    Thomas
+##  text5   804   2381        45 inaugCorpus.csv.5 1805  Jefferson    Thomas
 ## 
 ## Source:  /Users/kbenoit/Dropbox (Personal)/GitHub/readtext/vignettes/* on x86_64 by kbenoit
-## Created: Mon May 15 10:06:58 2017
+## Created: Mon May 15 12:58:43 2017
 ## Notes:</code></pre></div>
 </div>
 <div id="solving-common-problems" class="section level1">
@@ -353,7 +353,7 @@ fileencodings[notAvailableIndex]
 ## readtext object consisting of 36 documents and 3 docvars.
 ## # data.frame [36 × 5]
 ##                                doc_id                      text
-## *                               &lt;chr&gt;                     &lt;chr&gt;
+##                                 &lt;chr&gt;                     &lt;chr&gt;
 ## 1   IndianTreaty_English_UTF-16LE.txt           &quot;WHEREAS, t&quot;...
 ## 2  IndianTreaty_English_UTF-8-BOM.txt           &quot;ARTICLE 1.&quot;...
 ## 3          UDHR_Arabic_ISO-8859-6.txt          &quot;الديباجة\nل&quot;...
@@ -397,21 +397,21 @@ fileencodings[notAvailableIndex]
 <span class="kw">summary</span>(corpus_txts, <span class="dv">5</span>)
 ## Corpus consisting of 36 documents, showing 5 documents.
 ## 
-##                                Text Types Tokens Sentences     document
-##   IndianTreaty_English_UTF-16LE.txt   690   2938       155 IndianTreaty
-##  IndianTreaty_English_UTF-8-BOM.txt   646   3104       154 IndianTreaty
-##          UDHR_Arabic_ISO-8859-6.txt   753   1555        86         UDHR
-##               UDHR_Arabic_UTF-8.txt   753   1555        86         UDHR
-##        UDHR_Arabic_WINDOWS-1256.txt   753   1555        86         UDHR
-##  language input_encoding
-##   English       UTF-16LE
-##   English      UTF-8-BOM
-##    Arabic     ISO-8859-6
-##    Arabic          UTF-8
-##    Arabic   WINDOWS-1256
+##   Text Types Tokens Sentences                             doc_id
+##  text1   690   2938       155  IndianTreaty_English_UTF-16LE.txt
+##  text2   646   3104       154 IndianTreaty_English_UTF-8-BOM.txt
+##  text3   753   1555        86         UDHR_Arabic_ISO-8859-6.txt
+##  text4   753   1555        86              UDHR_Arabic_UTF-8.txt
+##  text5   753   1555        86       UDHR_Arabic_WINDOWS-1256.txt
+##      document language input_encoding
+##  IndianTreaty  English       UTF-16LE
+##  IndianTreaty  English      UTF-8-BOM
+##          UDHR   Arabic     ISO-8859-6
+##          UDHR   Arabic          UTF-8
+##          UDHR   Arabic   WINDOWS-1256
 ## 
 ## Source:  /Users/kbenoit/Dropbox (Personal)/GitHub/readtext/vignettes/* on x86_64 by kbenoit
-## Created: Mon May 15 10:06:58 2017
+## Created: Mon May 15 12:58:44 2017
 ## Notes:</code></pre></div>
 </div>
 </div>

--- a/man/readtext-package.Rd
+++ b/man/readtext-package.Rd
@@ -26,5 +26,5 @@ non-textual data.
 }
 
 \author{
-Ken Benoit, Paul Nulty, and Adam Obeng
+Ken Benoit, Adam Obeng, and Paul Nulty
 }

--- a/man/readtext.Rd
+++ b/man/readtext.Rd
@@ -104,9 +104,11 @@ as it would be give to \code{\link{iconv}}.  See the Encoding section of
 \link{file} for details.}
 }
 \value{
-a data.frame consisting of a first column \code{text} that contains
-the texts, with any additional columns consisting of document-level variables either found in the 
-file containing the texts, or created through the \code{readtext} call.
+a data.frame consisting of a columns \code{doc_id} and \code{text} 
+  that contain a document identifier and the texts respectively, with any 
+  additional columns consisting of document-level variables either found 
+  in the file containing the texts, or created through the 
+  \code{readtext} call.
 }
 \description{
 Read texts and (if any) associated document-level meta-data from one or more source files. 

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -10,14 +10,24 @@ library(quanteda)
 texts.readtext <- function(x, groups = NULL, ...) {
     if (!is.null(groups))
         stop("groups argument not supported for texts() on a readtext object")
-    result <- x[["text"]]
-    names(result) <- row.names(x)
-    result
+    as.character(x)
+    # result <- x[["text"]]
+    # names(result) <- row.names(x)
+    # result
 }
 docvars.readtext <- function(x, field = NULL) {
     if (!is.null(field))
         warning("field argument not used for docvars on a readtext object", noBreaks. = TRUE)
-    as.data.frame(x[, -which(names(x)=="text"), drop = FALSE])
+    as.data.frame(x[, -which(names(x) %in% c("doc_id", "text")), drop = FALSE])
 }
+
+docnames.readtext <- function(x) {
+    x[["doc_id"]]
+}
+
+ndoc.readtext <- function(x) {
+    nrow(x)
+}
+
 
 test_check("readtext")

--- a/tests/testthat/test-readtext.R
+++ b/tests/testthat/test-readtext.R
@@ -148,8 +148,7 @@ test_that("test csv files", {
     expect_that(
         docvars(testcorpus),
         equals(data.frame(list(colour = c('green', 'red'), number = c(42, 99)), 
-                          stringsAsFactors = FALSE, 
-                          row.names = c("test.csv.1", "test.csv.2")))
+                          stringsAsFactors = FALSE))
     )
     expect_equal(
         texts(testcorpus),
@@ -173,8 +172,7 @@ test_that("test tab files", {
     expect_that(
         docvars(testreadtext),
         equals(data.frame(list(colour=c('green', 'red'), number=c(42, 99)), 
-                          stringsAsFactors = FALSE,
-                          row.names = c("test.tab.1", "test.tab.2")))
+                          stringsAsFactors = FALSE))
     )
     expect_that(
         texts(testreadtext),
@@ -193,8 +191,7 @@ test_that("test tsv files", {
     expect_that(
         docvars(testreadtext),
         equals(data.frame(list(colour=c('green', 'red'), number=c(42, 99)), 
-                          stringsAsFactors=F,
-                          row.names = c("test.tsv.1", "test.tsv.2")))
+                          stringsAsFactors = FALSE))
     )
     expect_that(
         texts(testreadtext),
@@ -213,21 +210,19 @@ test_that("test xml files", {
     # Test corpus object
     testcorpus <- readtext('../data/xml/test.xml', text_field='text')
     expect_that(
-        data.frame(testcorpus[,-1]),
+        data.frame(testcorpus[,-c(1,2)]),
         equals(data.frame(list(colour=c('green', 'red'), number=c(42, 99)), 
-                          stringsAsFactors = FALSE,
-                          row.names = c("test.xml.1", "test.xml.2")))
+                          stringsAsFactors = FALSE))
     )
     expect_that(
         unname(texts(testcorpus)),
         equals(c('Lorem ipsum.','Dolor sit'))
     )
     expect_that(
-        row.names(testcorpus),
+        docnames(testcorpus),
         equals(c("test.xml.1", "test.xml.2"))
     )
 
-    
     expect_that(
         readtext('../data/xml/test.xml', text_field=1),
         gives_warning('You should specify text_field by name.*')
@@ -237,7 +232,7 @@ test_that("test xml files", {
         equals(c('Lorem ipsum.', 'Dolor sit'))
     )
     expect_that(
-        row.names(testcorpus),
+        docnames(testcorpus),
         equals(c("test.xml.1", "test.xml.2"))
     )
 
@@ -272,28 +267,25 @@ test_that("test readtext() with docvarsfrom=filenames", {
     expect_that(
         docvars(readtext('../data/docvars/one/*', docvarsfrom='filenames')),
         equals(data.frame(list(docvar1=c(1L, 2L), docvar2=c('apple', 'orange')), 
-                          stringsAsFactors = FALSE,
-                          row.names = c("1_apple.txt", "2_orange.txt")))
+                          stringsAsFactors = FALSE))
     )
     
     expect_that(
         docvars(readtext('../data/docvars/dash/*', docvarsfrom='filenames', dvsep='-')),
         equals(data.frame(list(docvar1=c(1,2), docvar2=c('apple', 'orange')), 
-                          stringsAsFactors = FALSE,
-                          row.names = c("1-apple.txt", "2-orange.txt")))
+                          stringsAsFactors = FALSE))
     )
     
     
     expect_that(
         docvars(readtext('../data/docvars/two/*txt', docvarsfrom='filenames')),
         equals(data.frame(list(docvar1=c(1,2), docvar2=c('apple', 'orange')), docvar3=c('red', 'orange'), 
-                          stringsAsFactors = FALSE,
-                          row.names = c("1_apple_red.txt", "2_orange_orange.txt")))
+                          stringsAsFactors = FALSE))
     )
     
     expect_that(
-        docvars(readtext('../data/docvars/two/*json', text_field='nonesuch', 
-                        docvarsfrom='filenames')),
+        docvars(readtext('../data/docvars/two/*json', text_field = 'nonesuch', 
+                        docvarsfrom = 'filenames')),
         throws_error("There is no field called")
     )
     
@@ -306,11 +298,9 @@ test_that("test readtext() with docvarsfrom=filenames", {
         docvars(readtext('../data/docvars/two/*txt', docvarsfrom='filenames',
                          docvarnames=c('id', 'fruit', 'colour'))),
         equals(data.frame(list(id=c(1,2), fruit=c('apple', 'orange')), 
-                          colour=c('red', 'orange'), stringsAsFactors=F,
-                          row.names = c("1_apple_red.txt", "2_orange_orange.txt")))
+                          colour=c('red', 'orange'), stringsAsFactors=F))
     )
-    
-    
+
     expect_that(
         docvars(readtext('../data/docvars/two/*txt', docvarsfrom='filenames',
                          docvarnames=c('id', 'fruit')
@@ -322,8 +312,7 @@ test_that("test readtext() with docvarsfrom=filenames", {
                          docvarnames=c('id', 'fruit')
         )),
         equals(data.frame(list(id=c(1,2), fruit=c('apple', 'orange')), 
-                          docvar3=c('red', 'orange'), stringsAsFactors = FALSE,
-                          row.names = c("1_apple_red.txt", "2_orange_orange.txt")))
+                          docvar3=c('red', 'orange'), stringsAsFactors = FALSE))
     )
     
     
@@ -344,8 +333,7 @@ test_that("test readtext() with docvarsfrom=filenames", {
     expect_equal(
         docvars(readtext('../data/docvars/csv/*', docvarsfrom=c('filenames'), docvarnames=c('id', 'fruit'), text_field='text')),
         data.frame(list(shape=c('round', NA), texture=c(NA, 'rough'), id=c(1, 2), fruit=c('apple', 'orange')), 
-                   stringsAsFactors = FALSE,
-                   row.names = c("1_apple.csv", "2_orange.csv"))
+                   stringsAsFactors = FALSE)
     )
     
     # #  Docvars from both metadata and filename
@@ -427,9 +415,7 @@ test_that("test reading structured text files with different columns", {
             color=c('green', 'orange', NA, NA), 
             shape=c(NA, NA, 'round', 'long')
         ),
-        stringsAsFactors=F,
-        row.names = c("1.csv.1", "1.csv.2", "2.csv.1", "2.csv.2")
-        ))
+        stringsAsFactors=F))
     )
     expected_texts <- c('apple', 'orange', 'apple', 'banana')
     names(expected_texts) <- c('1.csv.1', '1.csv.2', '2.csv.1', '2.csv.2')
@@ -529,13 +515,13 @@ test_that("Test function to list files", {
 test_that("Test function to list files with remote sources", {
     skip_on_cran()
     expect_error(
-      listMatchingFiles('http://www.google.com/404.txt'),
+      readtext:::listMatchingFiles('http://www.google.com/404.txt'),
       ".*404.*"
     )
     
     expect_equal(
-      length(readtext('http://www.google.com/404.txt', ignore_missing_files = TRUE)),
-      1
+      dim(readtext('http://www.google.com/404.txt', ignore_missing_files = TRUE)),
+      c(1,2)
     )
 })
 


### PR DESCRIPTION
Makes **readtext** output TIF-compliant for a corpus data.frame, and the `as.character(readtextobject)` TIF-compliant for a corpus character object.

Solves #92.